### PR TITLE
Markdown rendering via imgui_md + md4c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.26)
 
-project(nothofagus_project CXX)
+project(nothofagus_project CXX C)
 
 # ─────────────────────────────────────────────
 # Graphics backend selection
@@ -97,6 +97,7 @@ add_library(nothofagus
     "source/text.cpp"
     "source/animation_state_machine.cpp"
     "source/animation_state.cpp"
+    "source/markdown_renderer.cpp"
 
     # This is only required to show header files in the Visual Studio IDE solution browser
     ${NOTHOFAGUS_SOURCE_HEADERS}
@@ -230,6 +231,8 @@ target_include_directories(nothofagus
         "third_party/glad/include"
         ${NOTHOFAGUS_WIN_INCS}
         "third_party/font8x8"
+        "third_party/imgui_md"
+        "third_party/md4c/src"
 )
 target_link_libraries(nothofagus PRIVATE glad ${NOTHOFAGUS_WIN_LINK} imgui)
 # spdlog uses fmt to format string, this library requires /utf-8 when using MSVC

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -99,3 +99,9 @@ add_executable(hello_tilemap
 )
 set_property(TARGET hello_tilemap PROPERTY CXX_STANDARD 20)
 target_link_libraries(hello_tilemap PRIVATE nothofagus)
+
+add_executable(hello_markdown
+    "hello_markdown.cpp"
+)
+set_property(TARGET hello_markdown PROPERTY CXX_STANDARD 20)
+target_link_libraries(hello_markdown PRIVATE nothofagus)

--- a/examples/hello_markdown.cpp
+++ b/examples/hello_markdown.cpp
@@ -1,0 +1,90 @@
+#include <nothofagus.h>
+#include <imgui.h>
+#include <spdlog/spdlog.h>
+
+int main()
+{
+    Nothofagus::Canvas canvas({320, 240}, "Hello Markdown", {0.10f, 0.10f, 0.14f}, 3);
+
+    // Bake the typeset from the canvas's embedded TTF (Roboto). The bake API
+    // dedupes by (sourceId, sizePx), so bold/italic share the body font at
+    // 16 px — they are visually identical here. To get true bold/italic
+    // glyphs, register a dedicated bold or italic TTF via
+    // canvas.addImguiFontSource(...) and bake it at the same size, then
+    // point style.bold / style.italic at the new ids. Heading levels use
+    // distinct sizes, which is the main visual differentiator.
+    const Nothofagus::ImguiFontSourceId source = canvas.defaultImguiFontSourceId();
+    Nothofagus::ImguiFontId bodyId = canvas.bakeImguiFont(source, 16.0f);
+    Nothofagus::ImguiFontId codeId = canvas.bakeImguiFont(source, 14.0f);
+    Nothofagus::ImguiFontId h1Id   = canvas.bakeImguiFont(source, 28.0f);
+    Nothofagus::ImguiFontId h2Id   = canvas.bakeImguiFont(source, 22.0f);
+    Nothofagus::ImguiFontId h3Id   = canvas.bakeImguiFont(source, 18.0f);
+
+    Nothofagus::MarkdownStyle style;
+    style.regular     = bodyId;
+    style.bold        = bodyId;
+    style.italic      = bodyId;
+    style.code        = codeId;
+    style.headings[0] = h1Id;
+    style.headings[1] = h2Id;
+    style.headings[2] = h3Id;
+
+    Nothofagus::MarkdownRenderer markdown(canvas);
+    markdown.setStyle(style);
+    markdown.setOpenUrlCallback([](std::string_view url) {
+        spdlog::info("Markdown link clicked: {}", url);
+    });
+
+    static constexpr const char* kSample = R"md(# Hello Markdown
+
+Welcome to **Nothofagus** markdown rendering. This panel shows
+*emphasis*, **strong**, ***both***, and `inline code`.
+
+## Lists
+
+- Apples
+- Oranges
+  - Sub-item one
+  - Sub-item two
+- Bananas
+
+1. First
+2. Second
+3. Third
+
+## Code block
+
+```cpp
+canvas.run([&](float dt) {
+    markdown.print("# Heading");
+});
+```
+
+## Tables
+
+| feature       | supported |
+|---------------|-----------|
+| headings      | yes       |
+| code blocks   | yes       |
+| tables        | yes       |
+| inline images | no (v2)   |
+
+> Blockquotes work too. See [the repo](https://github.com/dantros/nothofagus)
+> for the project source. Strikethrough: ~~deprecated~~.
+
+---
+
+The horizontal rule above closes the document.
+)md";
+
+    canvas.run([&](float)
+    {
+        ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowSize(ImVec2(640.0f, 600.0f), ImGuiCond_FirstUseEver);
+        ImGui::Begin("Readme");
+        markdown.print(kSample);
+        ImGui::End();
+    });
+
+    return 0;
+}

--- a/include/markdown_renderer.h
+++ b/include/markdown_renderer.h
@@ -66,8 +66,8 @@ public:
     explicit MarkdownRenderer(Canvas& canvas);
     ~MarkdownRenderer();
 
-    MarkdownRenderer(const MarkdownRenderer&) = delete;
-    MarkdownRenderer& operator=(const MarkdownRenderer&) = delete;
+    MarkdownRenderer(const MarkdownRenderer&);
+    MarkdownRenderer& operator=(const MarkdownRenderer&);
     MarkdownRenderer(MarkdownRenderer&&) noexcept;
     MarkdownRenderer& operator=(MarkdownRenderer&&) noexcept;
 

--- a/include/markdown_renderer.h
+++ b/include/markdown_renderer.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include "imgui_font_id.h"
+
+namespace Nothofagus
+{
+
+class Canvas;
+
+/**
+ * @brief Per-element font mapping for `MarkdownRenderer`.
+ *
+ * Each slot is optional — when left empty (`std::nullopt`) the renderer falls
+ * back to the ImGui font that is current when `print(...)` is called. This
+ * lets users opt into bold/italic/heading variants incrementally instead of
+ * having to bake the full set up front.
+ *
+ * Bake fonts via `Canvas::bakeImguiFont(sourceId, sizePx)` and assign the
+ * resulting handles here. The same `ImguiFontId` can be reused across slots.
+ */
+struct MarkdownStyle
+{
+    std::optional<ImguiFontId> regular;
+    std::optional<ImguiFontId> bold;
+    std::optional<ImguiFontId> italic;
+    std::optional<ImguiFontId> boldItalic;
+    std::optional<ImguiFontId> code;                       ///< Monospace, used for inline code and fenced blocks.
+    std::array<std::optional<ImguiFontId>, 6> headings{};  ///< h1..h6 — slot index = heading level - 1.
+
+    bool tableBorder = true;
+    bool tableHeaderHighlight = true;
+};
+
+/**
+ * @brief Renders CommonMark / GFM-flavored markdown into the current ImGui window.
+ *
+ * Wraps the `mekhontsev/imgui_md` library (parser: `mity/md4c`) behind a
+ * Nothofagus-style API that uses `ImguiFontId` for font selection — keeping
+ * `ImFont*` out of user code. Call `print(text)` inside any ImGui scope
+ * (the `Canvas::run()` callback, a `renderImguiTo` callback, or just
+ * between an `ImGui::Begin/End` pair).
+ *
+ * Supported markdown subset (v1): headings (h1..h6), emphasis (bold,
+ * italic, bold-italic), inline code, fenced code blocks, unordered and
+ * ordered lists with nesting, blockquotes, horizontal rules, tables,
+ * links (with optional click callback), and strikethrough.
+ *
+ * **Inline images (`![alt](url)`) are not rendered in v1.** The parser still
+ * consumes them and skips them silently. See the project roadmap for
+ * image support — it requires a separate `TextureId → ImTextureID` bridge
+ * that handles the engine's layered (2D-array) texture format.
+ *
+ * Construction binds the renderer to a `Canvas&` for font resolution; the
+ * canvas must outlive the renderer.
+ */
+class MarkdownRenderer
+{
+public:
+    /// @param canvas Owning canvas — used to resolve `ImguiFontId` handles to
+    ///               `ImFont*` at render time. Must outlive this object.
+    explicit MarkdownRenderer(Canvas& canvas);
+    ~MarkdownRenderer();
+
+    MarkdownRenderer(const MarkdownRenderer&) = delete;
+    MarkdownRenderer& operator=(const MarkdownRenderer&) = delete;
+    MarkdownRenderer(MarkdownRenderer&&) noexcept;
+    MarkdownRenderer& operator=(MarkdownRenderer&&) noexcept;
+
+    /// Replace the font / table styling. Safe to call at any point; takes
+    /// effect on the next `print()` invocation.
+    void setStyle(const MarkdownStyle& style);
+    const MarkdownStyle& style() const noexcept;
+
+    /// Set a callback fired when the user clicks a `[text](url)` link.
+    /// Receives the raw URL string. Pass an empty `std::function` to disable.
+    void setOpenUrlCallback(std::function<void(std::string_view url)> callback);
+
+    /// Parse and render the given markdown source into the current ImGui
+    /// window. Must be called inside an active ImGui frame (between
+    /// `ImGui::NewFrame` and `ImGui::Render`, typically inside the
+    /// `Canvas::run` update callback or a `renderImguiTo` callback).
+    void print(std::string_view markdownText);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> mImpl;
+};
+
+} // namespace Nothofagus

--- a/include/nothofagus.h
+++ b/include/nothofagus.h
@@ -12,5 +12,6 @@
 #include "mouse.h"
 #include "gamepad.h"
 #include "text.h"
+#include "markdown_renderer.h"
 #include "animation_state.h"
 #include "animation_state_machine.h"

--- a/source/markdown_renderer.cpp
+++ b/source/markdown_renderer.cpp
@@ -9,13 +9,9 @@
 namespace Nothofagus
 {
 
-namespace
+struct MarkdownRenderer::Impl : public imgui_md
 {
-
-class NothofagusMarkdown : public imgui_md
-{
-public:
-    NothofagusMarkdown(Canvas& canvas) noexcept
+    explicit Impl(Canvas& canvas) noexcept
         : mCanvas(canvas)
     {
     }
@@ -99,15 +95,6 @@ private:
     std::function<void(std::string_view)> mOpenUrlCallback;
 };
 
-} // namespace
-
-struct MarkdownRenderer::Impl
-{
-    explicit Impl(Canvas& canvas) : markdown(canvas) {}
-
-    NothofagusMarkdown markdown;
-};
-
 MarkdownRenderer::MarkdownRenderer(Canvas& canvas)
     : mImpl(std::make_unique<Impl>(canvas))
 {
@@ -119,24 +106,24 @@ MarkdownRenderer& MarkdownRenderer::operator=(MarkdownRenderer&&) noexcept = def
 
 void MarkdownRenderer::setStyle(const MarkdownStyle& style)
 {
-    mImpl->markdown.setStyle(style);
+    mImpl->setStyle(style);
 }
 
 const MarkdownStyle& MarkdownRenderer::style() const noexcept
 {
-    return mImpl->markdown.style();
+    return mImpl->style();
 }
 
 void MarkdownRenderer::setOpenUrlCallback(std::function<void(std::string_view)> callback)
 {
-    mImpl->markdown.setOpenUrlCallback(std::move(callback));
+    mImpl->setOpenUrlCallback(std::move(callback));
 }
 
 void MarkdownRenderer::print(std::string_view markdownText)
 {
     const char* begin = markdownText.data();
     const char* end   = begin + markdownText.size();
-    mImpl->markdown.print(begin, end);
+    mImpl->print(begin, end);
 }
 
 } // namespace Nothofagus

--- a/source/markdown_renderer.cpp
+++ b/source/markdown_renderer.cpp
@@ -1,9 +1,11 @@
 #include "markdown_renderer.h"
 
 #include "canvas.h"
+#include "check.h"
 #include "imgui_md.h"
 
 #include <imgui.h>
+#include <spdlog/spdlog.h>
 #include <utility>
 
 namespace Nothofagus
@@ -85,8 +87,12 @@ protected:
 private:
     ImFont* resolve(ImguiFontId id) const
     {
+        debugCheck(mCanvas != nullptr, "MarkdownRenderer has unbound canvas");
         if (mCanvas == nullptr)
+        {
+            spdlog::error("MarkdownRenderer::resolve called on a renderer with an unbound canvas");
             return nullptr;  // unbound canvas — fall back to current font
+        }
         if (!mCanvas->isImguiFontReady(id))
             return nullptr;  // deferred-bake window — defer to current font
         return mCanvas->getImguiFontPtr(id);

--- a/source/markdown_renderer.cpp
+++ b/source/markdown_renderer.cpp
@@ -12,7 +12,7 @@ namespace Nothofagus
 struct MarkdownRenderer::Impl : public imgui_md
 {
     explicit Impl(Canvas& canvas) noexcept
-        : mCanvas(canvas)
+        : mCanvas(&canvas)
     {
     }
 
@@ -85,12 +85,14 @@ protected:
 private:
     ImFont* resolve(ImguiFontId id) const
     {
-        if (!mCanvas.isImguiFontReady(id))
+        if (mCanvas == nullptr)
+            return nullptr;  // unbound canvas — fall back to current font
+        if (!mCanvas->isImguiFontReady(id))
             return nullptr;  // deferred-bake window — defer to current font
-        return mCanvas.getImguiFontPtr(id);
+        return mCanvas->getImguiFontPtr(id);
     }
 
-    Canvas& mCanvas;
+    Canvas* mCanvas;
     MarkdownStyle mStyle{};
     std::function<void(std::string_view)> mOpenUrlCallback;
 };
@@ -103,6 +105,18 @@ MarkdownRenderer::MarkdownRenderer(Canvas& canvas)
 MarkdownRenderer::~MarkdownRenderer() = default;
 MarkdownRenderer::MarkdownRenderer(MarkdownRenderer&&) noexcept = default;
 MarkdownRenderer& MarkdownRenderer::operator=(MarkdownRenderer&&) noexcept = default;
+
+MarkdownRenderer::MarkdownRenderer(const MarkdownRenderer& other)
+    : mImpl(std::make_unique<Impl>(*other.mImpl))
+{
+}
+
+MarkdownRenderer& MarkdownRenderer::operator=(const MarkdownRenderer& other)
+{
+    if (this != &other)
+        mImpl = std::make_unique<Impl>(*other.mImpl);
+    return *this;
+}
 
 void MarkdownRenderer::setStyle(const MarkdownStyle& style)
 {

--- a/source/markdown_renderer.cpp
+++ b/source/markdown_renderer.cpp
@@ -1,0 +1,142 @@
+#include "markdown_renderer.h"
+
+#include "canvas.h"
+#include "imgui_md.h"
+
+#include <imgui.h>
+#include <utility>
+
+namespace Nothofagus
+{
+
+namespace
+{
+
+class NothofagusMarkdown : public imgui_md
+{
+public:
+    NothofagusMarkdown(Canvas& canvas) noexcept
+        : mCanvas(canvas)
+    {
+    }
+
+    void setStyle(const MarkdownStyle& style)
+    {
+        mStyle = style;
+        m_table_border           = style.tableBorder;
+        m_table_header_highlight = style.tableHeaderHighlight;
+    }
+
+    const MarkdownStyle& style() const noexcept { return mStyle; }
+
+    void setOpenUrlCallback(std::function<void(std::string_view)> callback)
+    {
+        mOpenUrlCallback = std::move(callback);
+    }
+
+protected:
+    ImFont* get_font() const override
+    {
+        // Heading levels override everything else; spec follows imgui_md's
+        // convention of m_hlevel == 0 meaning body text.
+        if (m_hlevel >= 1 && m_hlevel <= 6)
+        {
+            if (auto headingId = mStyle.headings[m_hlevel - 1])
+                return resolve(*headingId);
+        }
+
+        if (m_is_code)
+        {
+            if (auto codeId = mStyle.code)
+                return resolve(*codeId);
+        }
+
+        if (m_is_strong && m_is_em)
+        {
+            if (auto id = mStyle.boldItalic) return resolve(*id);
+            // Fall back to bold or italic individually if bold-italic is missing.
+            if (auto id = mStyle.bold)       return resolve(*id);
+            if (auto id = mStyle.italic)     return resolve(*id);
+        }
+        else if (m_is_strong)
+        {
+            if (auto id = mStyle.bold)       return resolve(*id);
+        }
+        else if (m_is_em)
+        {
+            if (auto id = mStyle.italic)     return resolve(*id);
+        }
+
+        if (auto id = mStyle.regular)        return resolve(*id);
+
+        return nullptr;  // imgui_md interprets nullptr as "use current font"
+    }
+
+    // v1 deliberately does not render inline images. The base class's default
+    // would draw the ImGui font atlas as a stand-in, which is worse than just
+    // skipping. Returning false leaves the image out entirely.
+    bool get_image(image_info&) const override
+    {
+        return false;
+    }
+
+    void open_url() const override
+    {
+        if (mOpenUrlCallback)
+            mOpenUrlCallback(std::string_view(m_href.data(), m_href.size()));
+    }
+
+private:
+    ImFont* resolve(ImguiFontId id) const
+    {
+        if (!mCanvas.isImguiFontReady(id))
+            return nullptr;  // deferred-bake window — defer to current font
+        return mCanvas.getImguiFontPtr(id);
+    }
+
+    Canvas& mCanvas;
+    MarkdownStyle mStyle{};
+    std::function<void(std::string_view)> mOpenUrlCallback;
+};
+
+} // namespace
+
+struct MarkdownRenderer::Impl
+{
+    explicit Impl(Canvas& canvas) : markdown(canvas) {}
+
+    NothofagusMarkdown markdown;
+};
+
+MarkdownRenderer::MarkdownRenderer(Canvas& canvas)
+    : mImpl(std::make_unique<Impl>(canvas))
+{
+}
+
+MarkdownRenderer::~MarkdownRenderer() = default;
+MarkdownRenderer::MarkdownRenderer(MarkdownRenderer&&) noexcept = default;
+MarkdownRenderer& MarkdownRenderer::operator=(MarkdownRenderer&&) noexcept = default;
+
+void MarkdownRenderer::setStyle(const MarkdownStyle& style)
+{
+    mImpl->markdown.setStyle(style);
+}
+
+const MarkdownStyle& MarkdownRenderer::style() const noexcept
+{
+    return mImpl->markdown.style();
+}
+
+void MarkdownRenderer::setOpenUrlCallback(std::function<void(std::string_view)> callback)
+{
+    mImpl->markdown.setOpenUrlCallback(std::move(callback));
+}
+
+void MarkdownRenderer::print(std::string_view markdownText)
+{
+    const char* begin = markdownText.data();
+    const char* end   = begin + markdownText.size();
+    mImpl->markdown.print(begin, end);
+}
+
+} // namespace Nothofagus

--- a/third_party/SOURCES.md
+++ b/third_party/SOURCES.md
@@ -12,6 +12,8 @@ Dependencies are vendored via `git subtree`. Use the commands below to update a 
 | `vk-bootstrap` | https://github.com/charles-lunarg/vk-bootstrap |
 | `VulkanMemoryAllocator` | https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator |
 | `imgui-filebrowser` | https://github.com/AirGuanZ/imgui-filebrowser.git |
+| `md4c`       | https://github.com/mity/md4c.git              |
+| `imgui_md`   | https://github.com/mekhontsev/imgui_md.git    |
 
 `glad` and `imgui_cmake` are custom local code — not managed by subtree.
 

--- a/third_party/imgui_cmake/CMakeLists.txt
+++ b/third_party/imgui_cmake/CMakeLists.txt
@@ -36,10 +36,14 @@ add_library(imgui STATIC
     "${IMGUI_PATH}/imgui_widgets.cpp"
     "${IMGUI_BACKEND_SRC}"
     ${IMGUI_BACKEND_SOURCES}
+    "../md4c/src/md4c.c"
+    "../imgui_md/imgui_md.cpp"
 )
 set_property(TARGET imgui PROPERTY CXX_STANDARD 11)
 target_include_directories(imgui PRIVATE
     "${IMGUI_PATH}"
+    "../md4c/src"
+    "../imgui_md"
     ${IMGUI_BACKEND_INC}
 )
 if(IMGUI_BACKEND_DEFS)


### PR DESCRIPTION
Adds `Nothofagus::MarkdownRenderer`, a public wrapper around the vendored `third_party/imgui_md` (mekhontsev) and `third_party/md4c` (mity) that renders CommonMark / GFM-flavored markdown into the current ImGui window. Call `print(text)` inside any ImGui scope — the `Canvas::run` update callback, a `renderImguiTo` callback, or just between an
`ImGui::Begin/End` pair.

Per-element styling is configured via `MarkdownStyle`, which maps regular / bold / italic / bold-italic / inline-code / h1..h6 to `ImguiFontId` handles baked through `Canvas::bakeImguiFont`. Each slot is optional — empty slots fall back to the ImGui font that is current when `print` runs, so users can opt into variants incrementally instead of having to bake the full set up front. `ImFont*` stays out of the public surface entirely.

Supports headings (h1..h6), emphasis (bold / italic / bold-italic), inline code, fenced code blocks, ordered + unordered nested lists, blockquotes, horizontal rules, tables (with `tableBorder` and `tableHeaderHighlight` toggles), strikethrough, and `[text](url)` links with an optional `setOpenUrlCallback`.

Inline images (`![alt](url)`) are intentionally not rendered in v1 — they would require a `TextureId → ImTextureID` bridge that handles the engine's layered texture format, which is deferred. The parser still consumes them and skips them silently.

New `examples/hello_markdown.cpp` demonstrates the full flow: baking fonts at different sizes, wiring up the style mapping, and printing a representative markdown document.

https://github.com/dantros/nothofagus/issues/55