### PR TITLE
Removing tick overloads from CanvasImpl, they live within Canvas only

### DIFF
--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -336,12 +336,14 @@ void Canvas::tick(float deltaTime, std::function<void(float)> update, Controller
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update)
 {
-    mCanvasImpl->tick(*this, deltaTime, update);
+    Controller controller;
+    mCanvasImpl->tick(*this, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime)
 {
-    mCanvasImpl->tick(*this, deltaTime);
+    Controller controller;
+    mCanvasImpl->tick(*this, deltaTime, [](float){}, controller);
 }
 
 void Canvas::close()

--- a/source/canvas_impl.cpp
+++ b/source/canvas_impl.cpp
@@ -495,17 +495,6 @@ void Canvas::CanvasImpl::tick(Canvas& canvas, float deltaTimeMS, std::function<v
     runOneFrame(canvas, deltaTimeMS, update, controller);
 }
 
-void Canvas::CanvasImpl::tick(Canvas& canvas, float deltaTimeMS, std::function<void(float)> update)
-{
-    Controller controller;
-    tick(canvas, deltaTimeMS, update, controller);
-}
-
-void Canvas::CanvasImpl::tick(Canvas& canvas, float deltaTimeMS)
-{
-    tick(canvas, deltaTimeMS, [](float){});
-}
-
 void Canvas::CanvasImpl::close()
 {
     mWindow->requestClose();

--- a/source/canvas_impl.h
+++ b/source/canvas_impl.h
@@ -136,8 +136,6 @@ public:
 
     /// Execute a single frame with a caller-supplied delta time (in milliseconds).
     void tick(Canvas& canvas, float deltaTimeMS, std::function<void(float)> update, Controller& controller);
-    void tick(Canvas& canvas, float deltaTimeMS, std::function<void(float)> update);
-    void tick(Canvas& canvas, float deltaTimeMS);
 
     /// Captures the last rendered frame visible to the user as a DirectTexture (RGBA).
     DirectTexture takeScreenshot() const;


### PR DESCRIPTION
https://github.com/dantros/nothofagus/issues/45