### PR TITLE
Canvas Modularization, extract FrameRunner / AssetRegistry / ImguiRttManager as peer collaborators

### DIFF
--- a/include/canvas.h
+++ b/include/canvas.h
@@ -492,7 +492,7 @@ public:
 
 private:
     struct Implementation;
-    std::unique_ptr<Implementation> mImplementation;
+    std::unique_ptr<Implementation> mImplPtr;
 };
 
 }

--- a/include/canvas.h
+++ b/include/canvas.h
@@ -492,7 +492,8 @@ public:
 
 private:
     class CanvasImpl;
-    std::unique_ptr<CanvasImpl> mCanvasImpl;
+    struct Private;
+    std::unique_ptr<Private> mPrivate;
 };
 
 }

--- a/include/canvas.h
+++ b/include/canvas.h
@@ -492,8 +492,8 @@ public:
 
 private:
     class CanvasImpl;
-    struct Private;
-    std::unique_ptr<Private> mPrivate;
+    struct Implementation;
+    std::unique_ptr<Implementation> mImplementation;
 };
 
 }

--- a/include/canvas.h
+++ b/include/canvas.h
@@ -491,7 +491,6 @@ public:
     DirectTexture takeScreenshot() const;
 
 private:
-    class CanvasImpl;
     struct Implementation;
     std::unique_ptr<Implementation> mImplementation;
 };

--- a/include/controller.h
+++ b/include/controller.h
@@ -215,7 +215,7 @@ public:
     void updateMousePosition(glm::vec2 position);
     void scrolled(glm::vec2 offset);
 
-    // Internal — gamepad (called by CanvasImpl each frame)
+    // Internal — gamepad (called by FrameRunner each frame)
     void activateGamepadButton(GamepadButtonTrigger trigger);
     void updateGamepadAxis(int gamepadId, GamepadAxis axis, float value);
     void gamepadConnected(int gamepadId);

--- a/source/asset_registry.h
+++ b/source/asset_registry.h
@@ -33,7 +33,7 @@ using MeshUsageMonitor    = ResourceUsageMonitor<MeshId>;
 /// the caller can sequence it against the backend's own shutdown.
 ///
 /// Does NOT enforce tilemap-pool-ownership gates or tear down ImGui RTT
-/// secondary contexts — both are CanvasImpl-level concerns layered on top
+/// secondary contexts — both are FrameRunner-level concerns layered on top
 /// of this class.
 class AssetRegistry
 {
@@ -84,7 +84,7 @@ public:
     RenderTargetContainer& renderTargets() { return mRenderTargets; }
     const RenderTargetContainer& renderTargets() const { return mRenderTargets; }
 
-    /// Free every GPU handle held by any container. Call from CanvasImpl's
+    /// Free every GPU handle held by any container. Call from FrameRunner's
     /// destructor before mBackend.shutdown(). After this call the registry
     /// is logically empty.
     void freeAllGpuResources();

--- a/source/backends/vulkan_backend.cpp
+++ b/source/backends/vulkan_backend.cpp
@@ -841,7 +841,7 @@ void VulkanBackend::shutdown()
     vkDestroyDescriptorPool(mDevice, mImguiDescriptorPool, nullptr);
 
     // Per-RTT ImGui descriptor pools (secondary contexts were already shut down by
-    // CanvasImpl before freeing the render targets, so only the pool remains).
+    // FrameRunner before freeing the render targets, so only the pool remains).
     for (auto& [id, pool] : mRttImguiDescriptorPools)
         vkDestroyDescriptorPool(mDevice, pool, nullptr);
     mRttImguiDescriptorPools.clear();

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -10,9 +10,9 @@ namespace Nothofagus
 {
 
 /**
- * @struct Canvas::Private
+ * @struct Canvas::Implementation
  * @brief Single nested pimpl holding every internal collaborator. Owning a
- *        single Private struct lets `canvas.h` expose only this one nested
+ *        single Implementation struct lets `canvas.h` expose only this one nested
  *        forward declaration — `Nothofagus::AssetRegistry` and
  *        `Nothofagus::ImguiRttManager` never appear in the public header.
  *
@@ -20,7 +20,7 @@ namespace Nothofagus
  * matches the GPU teardown sequence (ImGui RTT contexts → asset GPU handles
  * → ~CanvasImpl runs mBackend.shutdown()).
  */
-struct Canvas::Private
+struct Canvas::Implementation
 {
     std::unique_ptr<CanvasImpl>       canvasImpl;
     std::unique_ptr<AssetRegistry>    assets;
@@ -35,99 +35,99 @@ Canvas::Canvas(
     const float imguiFontSize,
     bool headless
 )
-    : mPrivate(std::make_unique<Private>())
+    : mImplementation(std::make_unique<Implementation>())
 {
     // Construction order matters: CanvasImpl builds mBackend and initializes
     // the GPU + ImGui main context. AssetRegistry takes a reference to that
     // backend. ImguiRttManager takes references to the backend AND the
     // registry's RenderTargetContainer. Finally bake the main HiDPI font
     // (needs the backend's ImGui renderer to be live).
-    mPrivate->canvasImpl = std::make_unique<CanvasImpl>(screenSize, title, clearColor, pixelSize, headless);
-    mPrivate->assets     = std::make_unique<AssetRegistry>(mPrivate->canvasImpl->backend());
-    mPrivate->imguiRtt   = std::make_unique<ImguiRttManager>(
-        mPrivate->canvasImpl->backend(),
-        mPrivate->assets->renderTargets(),
+    mImplementation->canvasImpl = std::make_unique<CanvasImpl>(screenSize, title, clearColor, pixelSize, headless);
+    mImplementation->assets     = std::make_unique<AssetRegistry>(mImplementation->canvasImpl->backend());
+    mImplementation->imguiRtt   = std::make_unique<ImguiRttManager>(
+        mImplementation->canvasImpl->backend(),
+        mImplementation->assets->renderTargets(),
         assets_Roboto_VariableFont_wdth_wght_ttf,
         assets_Roboto_VariableFont_wdth_wght_ttf_len,
         imguiFontSize);
-    mPrivate->imguiRtt->fonts().initialize(mPrivate->canvasImpl->contentScale());
+    mImplementation->imguiRtt->fonts().initialize(mImplementation->canvasImpl->contentScale());
 }
 
 Canvas::~Canvas()
 {
     // GPU resources must be freed while the backend is still alive. Drain
-    // imguiRtt and assets explicitly here; the unique_ptrs inside Private
+    // imguiRtt and assets explicitly here; the unique_ptrs inside Implementation
     // then destroy in reverse declaration order (imguiRtt → assets →
     // canvasImpl, where the last one shuts the backend down).
-    mPrivate->imguiRtt->releaseAll();
-    mPrivate->assets->freeAllGpuResources();
+    mImplementation->imguiRtt->releaseAll();
+    mImplementation->assets->freeAllGpuResources();
 }
 
 // ---------------------------------------------------------------------------
 // Window / display — forward to CanvasImpl
 // ---------------------------------------------------------------------------
 
-std::size_t Canvas::getCurrentMonitor() const                   { return mPrivate->canvasImpl->getCurrentMonitor(); }
-bool Canvas::isFullscreen() const                               { return mPrivate->canvasImpl->isFullscreen(); }
-void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mPrivate->canvasImpl->setFullScreenOnMonitor(monitor); }
-void Canvas::setWindowed()                                       { mPrivate->canvasImpl->setWindowed(); }
-const ScreenSize& Canvas::screenSize() const                    { return mPrivate->canvasImpl->screenSize(); }
-void Canvas::setScreenSize(const ScreenSize& screenSize)        { mPrivate->canvasImpl->setScreenSize(screenSize); }
-void Canvas::setClearColor(glm::vec3 clearColor)                { mPrivate->canvasImpl->setClearColor(clearColor); }
-void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mPrivate->canvasImpl->setAutoRemoveUnusedTextures(enabled); }
-void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mPrivate->canvasImpl->setAutoRemoveUnusedMeshes(enabled); }
-void Canvas::setWindowTitle(const std::string& title)           { mPrivate->canvasImpl->setWindowTitle(title); }
-ScreenSize Canvas::windowSize() const                            { return mPrivate->canvasImpl->windowSize(); }
-ViewportRect Canvas::gameViewport() const                       { return mPrivate->canvasImpl->gameViewport(); }
+std::size_t Canvas::getCurrentMonitor() const                   { return mImplementation->canvasImpl->getCurrentMonitor(); }
+bool Canvas::isFullscreen() const                               { return mImplementation->canvasImpl->isFullscreen(); }
+void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mImplementation->canvasImpl->setFullScreenOnMonitor(monitor); }
+void Canvas::setWindowed()                                       { mImplementation->canvasImpl->setWindowed(); }
+const ScreenSize& Canvas::screenSize() const                    { return mImplementation->canvasImpl->screenSize(); }
+void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplementation->canvasImpl->setScreenSize(screenSize); }
+void Canvas::setClearColor(glm::vec3 clearColor)                { mImplementation->canvasImpl->setClearColor(clearColor); }
+void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplementation->canvasImpl->setAutoRemoveUnusedTextures(enabled); }
+void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplementation->canvasImpl->setAutoRemoveUnusedMeshes(enabled); }
+void Canvas::setWindowTitle(const std::string& title)           { mImplementation->canvasImpl->setWindowTitle(title); }
+ScreenSize Canvas::windowSize() const                            { return mImplementation->canvasImpl->windowSize(); }
+ViewportRect Canvas::gameViewport() const                       { return mImplementation->canvasImpl->gameViewport(); }
 
 // ---------------------------------------------------------------------------
 // Bellotas — forward to AssetRegistry; remove gates against TilemapExplorer pool
 // ---------------------------------------------------------------------------
 
-BellotaId Canvas::addBellota(const Bellota& bellota)            { return mPrivate->assets->addBellota(bellota); }
+BellotaId Canvas::addBellota(const Bellota& bellota)            { return mImplementation->assets->addBellota(bellota); }
 
 void Canvas::removeBellota(const BellotaId bellotaId)
 {
-    debugCheck(!mPrivate->canvasImpl->isExplorerManagedBellota(bellotaId.id),
+    debugCheck(!mImplementation->canvasImpl->isExplorerManagedBellota(bellotaId.id),
         "Bellota is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot bellotas directly.");
-    mPrivate->assets->removeBellota(bellotaId);
+    mImplementation->assets->removeBellota(bellotaId);
 }
 
-Bellota& Canvas::bellota(BellotaId bellotaId)                   { return mPrivate->assets->bellota(bellotaId); }
-const Bellota& Canvas::bellota(BellotaId bellotaId) const       { return mPrivate->assets->bellota(bellotaId); }
-void Canvas::setTint(const BellotaId bellotaId, const Tint& tint) { mPrivate->assets->setTint(bellotaId, tint); }
-void Canvas::removeTint(const BellotaId bellotaId)              { mPrivate->assets->removeTint(bellotaId); }
+Bellota& Canvas::bellota(BellotaId bellotaId)                   { return mImplementation->assets->bellota(bellotaId); }
+const Bellota& Canvas::bellota(BellotaId bellotaId) const       { return mImplementation->assets->bellota(bellotaId); }
+void Canvas::setTint(const BellotaId bellotaId, const Tint& tint) { mImplementation->assets->setTint(bellotaId, tint); }
+void Canvas::removeTint(const BellotaId bellotaId)              { mImplementation->assets->removeTint(bellotaId); }
 
 // ---------------------------------------------------------------------------
 // Textures — forward to AssetRegistry; remove gates against TilemapExplorer pool
 // ---------------------------------------------------------------------------
 
-TextureId Canvas::addTexture(const Texture& texture)            { return mPrivate->assets->addTexture(texture); }
+TextureId Canvas::addTexture(const Texture& texture)            { return mImplementation->assets->addTexture(texture); }
 
 void Canvas::removeTexture(const TextureId textureId)
 {
-    debugCheck(!mPrivate->canvasImpl->isExplorerManagedTexture(textureId.id),
+    debugCheck(!mImplementation->canvasImpl->isExplorerManagedTexture(textureId.id),
         "Texture is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot textures directly.");
-    mPrivate->assets->removeTexture(textureId);
+    mImplementation->assets->removeTexture(textureId);
 }
 
-void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)            { mPrivate->assets->setTexture(bellotaId, textureId); }
-void Canvas::markTextureAsDirty(const TextureId textureId)                                { mPrivate->assets->markTextureAsDirty(textureId); }
-void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)       { mPrivate->assets->setTextureMinFilter(textureId, mode); }
-void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)       { mPrivate->assets->setTextureMagFilter(textureId, mode); }
-Texture& Canvas::texture(TextureId textureId)                                             { return mPrivate->assets->texture(textureId); }
-const Texture& Canvas::texture(TextureId textureId) const                                 { return mPrivate->assets->texture(textureId); }
+void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)            { mImplementation->assets->setTexture(bellotaId, textureId); }
+void Canvas::markTextureAsDirty(const TextureId textureId)                                { mImplementation->assets->markTextureAsDirty(textureId); }
+void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets->setTextureMinFilter(textureId, mode); }
+void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets->setTextureMagFilter(textureId, mode); }
+Texture& Canvas::texture(TextureId textureId)                                             { return mImplementation->assets->texture(textureId); }
+const Texture& Canvas::texture(TextureId textureId) const                                 { return mImplementation->assets->texture(textureId); }
 
 // ---------------------------------------------------------------------------
 // Meshes — forward to AssetRegistry
 // ---------------------------------------------------------------------------
 
-MeshId Canvas::addMesh(const Mesh& mesh)                                                  { return mPrivate->assets->addMesh(mesh); }
-MeshId Canvas::addMesh(Mesh&& mesh)                                                       { return mPrivate->assets->addMesh(std::move(mesh)); }
-void Canvas::removeMesh(MeshId meshId)                                                    { mPrivate->assets->removeMesh(meshId); }
-void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)                      { mPrivate->assets->setMesh(bellotaId, meshId); }
-const Mesh& Canvas::mesh(MeshId meshId) const                                             { return mPrivate->assets->mesh(meshId); }
-const Mesh& Canvas::mesh(BellotaId bellotaId) const                                       { return mPrivate->assets->mesh(bellotaId); }
+MeshId Canvas::addMesh(const Mesh& mesh)                                                  { return mImplementation->assets->addMesh(mesh); }
+MeshId Canvas::addMesh(Mesh&& mesh)                                                       { return mImplementation->assets->addMesh(std::move(mesh)); }
+void Canvas::removeMesh(MeshId meshId)                                                    { mImplementation->assets->removeMesh(meshId); }
+void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)                      { mImplementation->assets->setMesh(bellotaId, meshId); }
+const Mesh& Canvas::mesh(MeshId meshId) const                                             { return mImplementation->assets->mesh(meshId); }
+const Mesh& Canvas::mesh(BellotaId bellotaId) const                                       { return mImplementation->assets->mesh(bellotaId); }
 
 // ---------------------------------------------------------------------------
 // Render targets — forward to AssetRegistry; remove tears down the per-RTT
@@ -135,29 +135,29 @@ const Mesh& Canvas::mesh(BellotaId bellotaId) const                             
 // render pass / FBO that the registry is about to free).
 // ---------------------------------------------------------------------------
 
-RenderTargetId Canvas::addRenderTarget(ScreenSize size)                                   { return mPrivate->assets->addRenderTarget(size); }
+RenderTargetId Canvas::addRenderTarget(ScreenSize size)                                   { return mImplementation->assets->addRenderTarget(size); }
 
 void Canvas::removeRenderTarget(RenderTargetId renderTargetId)
 {
-    mPrivate->imguiRtt->releaseContext(renderTargetId);
-    mPrivate->assets->removeRenderTarget(renderTargetId);
+    mImplementation->imguiRtt->releaseContext(renderTargetId);
+    mImplementation->assets->removeRenderTarget(renderTargetId);
 }
 
-TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const                { return mPrivate->assets->renderTargetTexture(renderTargetId); }
-void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mPrivate->assets->setRenderTargetClearColor(renderTargetId, clearColor); }
+TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const                { return mImplementation->assets->renderTargetTexture(renderTargetId); }
+void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mImplementation->assets->setRenderTargetClearColor(renderTargetId, clearColor); }
 
 // ---------------------------------------------------------------------------
 // Tilemaps — forward to CanvasImpl (TilemapManager lives there)
 // ---------------------------------------------------------------------------
 
-TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mPrivate->canvasImpl->addTilemap(std::move(tilemap)); }
-void Canvas::removeTilemap(TilemapId tilemapId)                                            { mPrivate->canvasImpl->removeTilemap(tilemapId); }
-Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mPrivate->canvasImpl->tilemap(tilemapId); }
-const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mPrivate->canvasImpl->tilemap(tilemapId); }
-TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mPrivate->canvasImpl->addTilemapExplorer(explorer, *this); }
-void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mPrivate->canvasImpl->removeTilemapExplorer(explorerId, *this); }
-TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mPrivate->canvasImpl->tilemapExplorer(explorerId); }
-const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mPrivate->canvasImpl->tilemapExplorer(explorerId); }
+TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mImplementation->canvasImpl->addTilemap(std::move(tilemap)); }
+void Canvas::removeTilemap(TilemapId tilemapId)                                            { mImplementation->canvasImpl->removeTilemap(tilemapId); }
+Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mImplementation->canvasImpl->tilemap(tilemapId); }
+const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mImplementation->canvasImpl->tilemap(tilemapId); }
+TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mImplementation->canvasImpl->addTilemapExplorer(explorer, *this); }
+void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mImplementation->canvasImpl->removeTilemapExplorer(explorerId, *this); }
+TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mImplementation->canvasImpl->tilemapExplorer(explorerId); }
+const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mImplementation->canvasImpl->tilemapExplorer(explorerId); }
 
 // ---------------------------------------------------------------------------
 // RTT pass scheduling (the queue lives on CanvasImpl; the ImGui-to-RTT
@@ -166,7 +166,7 @@ const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) con
 
 void Canvas::renderTo(RenderTargetId renderTargetId, std::vector<BellotaId> bellotaIds)
 {
-    mPrivate->canvasImpl->renderTo(renderTargetId, std::move(bellotaIds));
+    mImplementation->canvasImpl->renderTo(renderTargetId, std::move(bellotaIds));
 }
 
 void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, ImguiDrawCallback imguiDrawCallback)
@@ -174,7 +174,7 @@ void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, Im
     // Wrap the user's callback with auto-push/pop of fontId. Graceful fallback:
     // if the bake is still pending or the id was removed, the callback runs
     // without an explicit push (the secondary-context default stays in effect).
-    mPrivate->imguiRtt->enqueue(renderTargetId,
+    mImplementation->imguiRtt->enqueue(renderTargetId,
         [this, fontId, cb = std::move(imguiDrawCallback)] {
             if (isImguiFontReady(fontId))
             {
@@ -190,16 +190,16 @@ void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, Im
 }
 
 // ---------------------------------------------------------------------------
-// ImGui fonts — forward to mPrivate->imguiRtt->fonts() (or wrap in imgui.h calls)
+// ImGui fonts — forward to mImplementation->imguiRtt->fonts() (or wrap in imgui.h calls)
 // ---------------------------------------------------------------------------
 
-ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mPrivate->imguiRtt->fonts().addSource(ttfBytes, glyphRange); }
-void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)                                          { mPrivate->imguiRtt->fonts().removeSource(sourceId); }
-ImguiFontSourceId Canvas::defaultImguiFontSourceId() const                                              { return mPrivate->imguiRtt->fonts().defaultSourceId(); }
-ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                             { return mPrivate->imguiRtt->fonts().bake(sourceId, sizePx); }
-void Canvas::removeImguiFont(ImguiFontId id)                                                            { mPrivate->imguiRtt->fonts().remove(id); }
-bool Canvas::isImguiFontReady(ImguiFontId id) const                                                     { return mPrivate->imguiRtt->fonts().get(id) != nullptr; }
-ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const                                                   { return mPrivate->imguiRtt->fonts().get(id); }
+ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mImplementation->imguiRtt->fonts().addSource(ttfBytes, glyphRange); }
+void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)                                          { mImplementation->imguiRtt->fonts().removeSource(sourceId); }
+ImguiFontSourceId Canvas::defaultImguiFontSourceId() const                                              { return mImplementation->imguiRtt->fonts().defaultSourceId(); }
+ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                             { return mImplementation->imguiRtt->fonts().bake(sourceId, sizePx); }
+void Canvas::removeImguiFont(ImguiFontId id)                                                            { mImplementation->imguiRtt->fonts().remove(id); }
+bool Canvas::isImguiFontReady(ImguiFontId id) const                                                     { return mImplementation->imguiRtt->fonts().get(id) != nullptr; }
+ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const                                                   { return mImplementation->imguiRtt->fonts().get(id); }
 
 void Canvas::pushImguiFont(ImguiFontId id)
 {
@@ -216,7 +216,7 @@ void Canvas::popImguiFont()
 
 ImguiFontId Canvas::defaultImguiFontId() const
 {
-    auto idOpt = mPrivate->imguiRtt->fonts().defaultFontId();
+    auto idOpt = mImplementation->imguiRtt->fonts().defaultFontId();
     debugCheck(idOpt.has_value(),
         "Canvas::defaultImguiFontId: no default font registered (Canvas ctor seeds this — should never fire)");
     return *idOpt;
@@ -226,8 +226,8 @@ ImguiFontId Canvas::defaultImguiFontId() const
 // Stats flag
 // ---------------------------------------------------------------------------
 
-bool& Canvas::stats()                                            { return mPrivate->canvasImpl->stats(); }
-const bool& Canvas::stats() const                                { return mPrivate->canvasImpl->stats(); }
+bool& Canvas::stats()                                            { return mImplementation->canvasImpl->stats(); }
+const bool& Canvas::stats() const                                { return mImplementation->canvasImpl->stats(); }
 
 // ---------------------------------------------------------------------------
 // Lifecycle — thread the assets + imguiRtt managers into the frame loop
@@ -237,45 +237,45 @@ void Canvas::run()
 {
     auto update = [](float){};
     Controller controller;
-    mPrivate->canvasImpl->run(*this, *mPrivate->assets, *mPrivate->imguiRtt, update, controller);
+    mImplementation->canvasImpl->run(*this, *mImplementation->assets, *mImplementation->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update)
 {
     Controller controller;
-    mPrivate->canvasImpl->run(*this, *mPrivate->assets, *mPrivate->imguiRtt, update, controller);
+    mImplementation->canvasImpl->run(*this, *mImplementation->assets, *mImplementation->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update, Controller& controller)
 {
-    mPrivate->canvasImpl->run(*this, *mPrivate->assets, *mPrivate->imguiRtt, update, controller);
+    mImplementation->canvasImpl->run(*this, *mImplementation->assets, *mImplementation->imguiRtt, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update, Controller& controller)
 {
-    mPrivate->canvasImpl->tick(*this, *mPrivate->assets, *mPrivate->imguiRtt, deltaTime, update, controller);
+    mImplementation->canvasImpl->tick(*this, *mImplementation->assets, *mImplementation->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update)
 {
     Controller controller;
-    mPrivate->canvasImpl->tick(*this, *mPrivate->assets, *mPrivate->imguiRtt, deltaTime, update, controller);
+    mImplementation->canvasImpl->tick(*this, *mImplementation->assets, *mImplementation->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime)
 {
     Controller controller;
-    mPrivate->canvasImpl->tick(*this, *mPrivate->assets, *mPrivate->imguiRtt, deltaTime, [](float){}, controller);
+    mImplementation->canvasImpl->tick(*this, *mImplementation->assets, *mImplementation->imguiRtt, deltaTime, [](float){}, controller);
 }
 
 void Canvas::close()
 {
-    mPrivate->canvasImpl->close();
+    mImplementation->canvasImpl->close();
 }
 
 DirectTexture Canvas::takeScreenshot() const
 {
-    return mPrivate->canvasImpl->takeScreenshot();
+    return mImplementation->canvasImpl->takeScreenshot();
 }
 
 }

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -59,7 +59,7 @@ Canvas::Canvas(
     const float imguiFontSize,
     bool headless
 )
-    : mImplementation(std::make_unique<Implementation>(
+    : mImplPtr(std::make_unique<Implementation>(
           screenSize, title, clearColor, pixelSize, imguiFontSize, headless))
 {
 }
@@ -70,75 +70,75 @@ Canvas::~Canvas()
     // imguiRtt and assets explicitly here; the by-value members inside
     // Implementation then destroy in reverse declaration order
     // (imguiRtt → assets → canvasImpl, where the last one shuts the backend down).
-    mImplementation->imguiRtt.releaseAll();
-    mImplementation->assets.freeAllGpuResources();
+    mImplPtr->imguiRtt.releaseAll();
+    mImplPtr->assets.freeAllGpuResources();
 }
 
 // ---------------------------------------------------------------------------
 // Window / display — forward to CanvasImpl
 // ---------------------------------------------------------------------------
 
-std::size_t Canvas::getCurrentMonitor() const                   { return mImplementation->canvasImpl.getCurrentMonitor(); }
-bool Canvas::isFullscreen() const                               { return mImplementation->canvasImpl.isFullscreen(); }
-void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mImplementation->canvasImpl.setFullScreenOnMonitor(monitor); }
-void Canvas::setWindowed()                                       { mImplementation->canvasImpl.setWindowed(); }
-const ScreenSize& Canvas::screenSize() const                    { return mImplementation->canvasImpl.screenSize(); }
-void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplementation->canvasImpl.setScreenSize(screenSize); }
-void Canvas::setClearColor(glm::vec3 clearColor)                { mImplementation->canvasImpl.setClearColor(clearColor); }
-void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplementation->canvasImpl.setAutoRemoveUnusedTextures(enabled); }
-void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplementation->canvasImpl.setAutoRemoveUnusedMeshes(enabled); }
-void Canvas::setWindowTitle(const std::string& title)           { mImplementation->canvasImpl.setWindowTitle(title); }
-ScreenSize Canvas::windowSize() const                            { return mImplementation->canvasImpl.windowSize(); }
-ViewportRect Canvas::gameViewport() const                       { return mImplementation->canvasImpl.gameViewport(); }
+std::size_t Canvas::getCurrentMonitor() const                   { return mImplPtr->canvasImpl.getCurrentMonitor(); }
+bool Canvas::isFullscreen() const                               { return mImplPtr->canvasImpl.isFullscreen(); }
+void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mImplPtr->canvasImpl.setFullScreenOnMonitor(monitor); }
+void Canvas::setWindowed()                                       { mImplPtr->canvasImpl.setWindowed(); }
+const ScreenSize& Canvas::screenSize() const                    { return mImplPtr->canvasImpl.screenSize(); }
+void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplPtr->canvasImpl.setScreenSize(screenSize); }
+void Canvas::setClearColor(glm::vec3 clearColor)                { mImplPtr->canvasImpl.setClearColor(clearColor); }
+void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplPtr->canvasImpl.setAutoRemoveUnusedTextures(enabled); }
+void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplPtr->canvasImpl.setAutoRemoveUnusedMeshes(enabled); }
+void Canvas::setWindowTitle(const std::string& title)           { mImplPtr->canvasImpl.setWindowTitle(title); }
+ScreenSize Canvas::windowSize() const                            { return mImplPtr->canvasImpl.windowSize(); }
+ViewportRect Canvas::gameViewport() const                       { return mImplPtr->canvasImpl.gameViewport(); }
 
 // ---------------------------------------------------------------------------
 // Bellotas — forward to AssetRegistry; remove gates against TilemapExplorer pool
 // ---------------------------------------------------------------------------
 
-BellotaId Canvas::addBellota(const Bellota& bellota)            { return mImplementation->assets.addBellota(bellota); }
+BellotaId Canvas::addBellota(const Bellota& bellota)            { return mImplPtr->assets.addBellota(bellota); }
 
 void Canvas::removeBellota(const BellotaId bellotaId)
 {
-    debugCheck(!mImplementation->canvasImpl.isExplorerManagedBellota(bellotaId.id),
+    debugCheck(!mImplPtr->canvasImpl.isExplorerManagedBellota(bellotaId.id),
         "Bellota is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot bellotas directly.");
-    mImplementation->assets.removeBellota(bellotaId);
+    mImplPtr->assets.removeBellota(bellotaId);
 }
 
-Bellota& Canvas::bellota(BellotaId bellotaId)                   { return mImplementation->assets.bellota(bellotaId); }
-const Bellota& Canvas::bellota(BellotaId bellotaId) const       { return mImplementation->assets.bellota(bellotaId); }
-void Canvas::setTint(const BellotaId bellotaId, const Tint& tint) { mImplementation->assets.setTint(bellotaId, tint); }
-void Canvas::removeTint(const BellotaId bellotaId)              { mImplementation->assets.removeTint(bellotaId); }
+Bellota& Canvas::bellota(BellotaId bellotaId)                   { return mImplPtr->assets.bellota(bellotaId); }
+const Bellota& Canvas::bellota(BellotaId bellotaId) const       { return mImplPtr->assets.bellota(bellotaId); }
+void Canvas::setTint(const BellotaId bellotaId, const Tint& tint) { mImplPtr->assets.setTint(bellotaId, tint); }
+void Canvas::removeTint(const BellotaId bellotaId)              { mImplPtr->assets.removeTint(bellotaId); }
 
 // ---------------------------------------------------------------------------
 // Textures — forward to AssetRegistry; remove gates against TilemapExplorer pool
 // ---------------------------------------------------------------------------
 
-TextureId Canvas::addTexture(const Texture& texture)            { return mImplementation->assets.addTexture(texture); }
+TextureId Canvas::addTexture(const Texture& texture)            { return mImplPtr->assets.addTexture(texture); }
 
 void Canvas::removeTexture(const TextureId textureId)
 {
-    debugCheck(!mImplementation->canvasImpl.isExplorerManagedTexture(textureId.id),
+    debugCheck(!mImplPtr->canvasImpl.isExplorerManagedTexture(textureId.id),
         "Texture is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot textures directly.");
-    mImplementation->assets.removeTexture(textureId);
+    mImplPtr->assets.removeTexture(textureId);
 }
 
-void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)            { mImplementation->assets.setTexture(bellotaId, textureId); }
-void Canvas::markTextureAsDirty(const TextureId textureId)                                { mImplementation->assets.markTextureAsDirty(textureId); }
-void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets.setTextureMinFilter(textureId, mode); }
-void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets.setTextureMagFilter(textureId, mode); }
-Texture& Canvas::texture(TextureId textureId)                                             { return mImplementation->assets.texture(textureId); }
-const Texture& Canvas::texture(TextureId textureId) const                                 { return mImplementation->assets.texture(textureId); }
+void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)            { mImplPtr->assets.setTexture(bellotaId, textureId); }
+void Canvas::markTextureAsDirty(const TextureId textureId)                                { mImplPtr->assets.markTextureAsDirty(textureId); }
+void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)       { mImplPtr->assets.setTextureMinFilter(textureId, mode); }
+void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)       { mImplPtr->assets.setTextureMagFilter(textureId, mode); }
+Texture& Canvas::texture(TextureId textureId)                                             { return mImplPtr->assets.texture(textureId); }
+const Texture& Canvas::texture(TextureId textureId) const                                 { return mImplPtr->assets.texture(textureId); }
 
 // ---------------------------------------------------------------------------
 // Meshes — forward to AssetRegistry
 // ---------------------------------------------------------------------------
 
-MeshId Canvas::addMesh(const Mesh& mesh)                                                  { return mImplementation->assets.addMesh(mesh); }
-MeshId Canvas::addMesh(Mesh&& mesh)                                                       { return mImplementation->assets.addMesh(std::move(mesh)); }
-void Canvas::removeMesh(MeshId meshId)                                                    { mImplementation->assets.removeMesh(meshId); }
-void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)                      { mImplementation->assets.setMesh(bellotaId, meshId); }
-const Mesh& Canvas::mesh(MeshId meshId) const                                             { return mImplementation->assets.mesh(meshId); }
-const Mesh& Canvas::mesh(BellotaId bellotaId) const                                       { return mImplementation->assets.mesh(bellotaId); }
+MeshId Canvas::addMesh(const Mesh& mesh)                                                  { return mImplPtr->assets.addMesh(mesh); }
+MeshId Canvas::addMesh(Mesh&& mesh)                                                       { return mImplPtr->assets.addMesh(std::move(mesh)); }
+void Canvas::removeMesh(MeshId meshId)                                                    { mImplPtr->assets.removeMesh(meshId); }
+void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)                      { mImplPtr->assets.setMesh(bellotaId, meshId); }
+const Mesh& Canvas::mesh(MeshId meshId) const                                             { return mImplPtr->assets.mesh(meshId); }
+const Mesh& Canvas::mesh(BellotaId bellotaId) const                                       { return mImplPtr->assets.mesh(bellotaId); }
 
 // ---------------------------------------------------------------------------
 // Render targets — forward to AssetRegistry; remove tears down the per-RTT
@@ -146,29 +146,29 @@ const Mesh& Canvas::mesh(BellotaId bellotaId) const                             
 // render pass / FBO that the registry is about to free).
 // ---------------------------------------------------------------------------
 
-RenderTargetId Canvas::addRenderTarget(ScreenSize size)                                   { return mImplementation->assets.addRenderTarget(size); }
+RenderTargetId Canvas::addRenderTarget(ScreenSize size)                                   { return mImplPtr->assets.addRenderTarget(size); }
 
 void Canvas::removeRenderTarget(RenderTargetId renderTargetId)
 {
-    mImplementation->imguiRtt.releaseContext(renderTargetId);
-    mImplementation->assets.removeRenderTarget(renderTargetId);
+    mImplPtr->imguiRtt.releaseContext(renderTargetId);
+    mImplPtr->assets.removeRenderTarget(renderTargetId);
 }
 
-TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const                { return mImplementation->assets.renderTargetTexture(renderTargetId); }
-void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mImplementation->assets.setRenderTargetClearColor(renderTargetId, clearColor); }
+TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const                { return mImplPtr->assets.renderTargetTexture(renderTargetId); }
+void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mImplPtr->assets.setRenderTargetClearColor(renderTargetId, clearColor); }
 
 // ---------------------------------------------------------------------------
 // Tilemaps — forward to CanvasImpl (TilemapManager lives there)
 // ---------------------------------------------------------------------------
 
-TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mImplementation->canvasImpl.addTilemap(std::move(tilemap)); }
-void Canvas::removeTilemap(TilemapId tilemapId)                                            { mImplementation->canvasImpl.removeTilemap(tilemapId); }
-Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mImplementation->canvasImpl.tilemap(tilemapId); }
-const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mImplementation->canvasImpl.tilemap(tilemapId); }
-TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mImplementation->canvasImpl.addTilemapExplorer(explorer, *this); }
-void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mImplementation->canvasImpl.removeTilemapExplorer(explorerId, *this); }
-TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mImplementation->canvasImpl.tilemapExplorer(explorerId); }
-const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mImplementation->canvasImpl.tilemapExplorer(explorerId); }
+TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mImplPtr->canvasImpl.addTilemap(std::move(tilemap)); }
+void Canvas::removeTilemap(TilemapId tilemapId)                                            { mImplPtr->canvasImpl.removeTilemap(tilemapId); }
+Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mImplPtr->canvasImpl.tilemap(tilemapId); }
+const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mImplPtr->canvasImpl.tilemap(tilemapId); }
+TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mImplPtr->canvasImpl.addTilemapExplorer(explorer, *this); }
+void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mImplPtr->canvasImpl.removeTilemapExplorer(explorerId, *this); }
+TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mImplPtr->canvasImpl.tilemapExplorer(explorerId); }
+const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mImplPtr->canvasImpl.tilemapExplorer(explorerId); }
 
 // ---------------------------------------------------------------------------
 // RTT pass scheduling (the queue lives on CanvasImpl; the ImGui-to-RTT
@@ -177,7 +177,7 @@ const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) con
 
 void Canvas::renderTo(RenderTargetId renderTargetId, std::vector<BellotaId> bellotaIds)
 {
-    mImplementation->canvasImpl.renderTo(renderTargetId, std::move(bellotaIds));
+    mImplPtr->canvasImpl.renderTo(renderTargetId, std::move(bellotaIds));
 }
 
 void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, ImguiDrawCallback imguiDrawCallback)
@@ -185,7 +185,7 @@ void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, Im
     // Wrap the user's callback with auto-push/pop of fontId. Graceful fallback:
     // if the bake is still pending or the id was removed, the callback runs
     // without an explicit push (the secondary-context default stays in effect).
-    mImplementation->imguiRtt.enqueue(renderTargetId,
+    mImplPtr->imguiRtt.enqueue(renderTargetId,
         [this, fontId, cb = std::move(imguiDrawCallback)] {
             if (isImguiFontReady(fontId))
             {
@@ -201,16 +201,16 @@ void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, Im
 }
 
 // ---------------------------------------------------------------------------
-// ImGui fonts — forward to mImplementation->imguiRtt.fonts() (or wrap in imgui.h calls)
+// ImGui fonts — forward to mImplPtr->imguiRtt.fonts() (or wrap in imgui.h calls)
 // ---------------------------------------------------------------------------
 
-ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mImplementation->imguiRtt.fonts().addSource(ttfBytes, glyphRange); }
-void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)                                          { mImplementation->imguiRtt.fonts().removeSource(sourceId); }
-ImguiFontSourceId Canvas::defaultImguiFontSourceId() const                                              { return mImplementation->imguiRtt.fonts().defaultSourceId(); }
-ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                             { return mImplementation->imguiRtt.fonts().bake(sourceId, sizePx); }
-void Canvas::removeImguiFont(ImguiFontId id)                                                            { mImplementation->imguiRtt.fonts().remove(id); }
-bool Canvas::isImguiFontReady(ImguiFontId id) const                                                     { return mImplementation->imguiRtt.fonts().get(id) != nullptr; }
-ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const                                                   { return mImplementation->imguiRtt.fonts().get(id); }
+ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mImplPtr->imguiRtt.fonts().addSource(ttfBytes, glyphRange); }
+void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)                                          { mImplPtr->imguiRtt.fonts().removeSource(sourceId); }
+ImguiFontSourceId Canvas::defaultImguiFontSourceId() const                                              { return mImplPtr->imguiRtt.fonts().defaultSourceId(); }
+ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                             { return mImplPtr->imguiRtt.fonts().bake(sourceId, sizePx); }
+void Canvas::removeImguiFont(ImguiFontId id)                                                            { mImplPtr->imguiRtt.fonts().remove(id); }
+bool Canvas::isImguiFontReady(ImguiFontId id) const                                                     { return mImplPtr->imguiRtt.fonts().get(id) != nullptr; }
+ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const                                                   { return mImplPtr->imguiRtt.fonts().get(id); }
 
 void Canvas::pushImguiFont(ImguiFontId id)
 {
@@ -227,7 +227,7 @@ void Canvas::popImguiFont()
 
 ImguiFontId Canvas::defaultImguiFontId() const
 {
-    auto idOpt = mImplementation->imguiRtt.fonts().defaultFontId();
+    auto idOpt = mImplPtr->imguiRtt.fonts().defaultFontId();
     debugCheck(idOpt.has_value(),
         "Canvas::defaultImguiFontId: no default font registered (Canvas ctor seeds this — should never fire)");
     return *idOpt;
@@ -237,8 +237,8 @@ ImguiFontId Canvas::defaultImguiFontId() const
 // Stats flag
 // ---------------------------------------------------------------------------
 
-bool& Canvas::stats()                                            { return mImplementation->canvasImpl.stats(); }
-const bool& Canvas::stats() const                                { return mImplementation->canvasImpl.stats(); }
+bool& Canvas::stats()                                            { return mImplPtr->canvasImpl.stats(); }
+const bool& Canvas::stats() const                                { return mImplPtr->canvasImpl.stats(); }
 
 // ---------------------------------------------------------------------------
 // Lifecycle — thread the assets + imguiRtt managers into the frame loop
@@ -248,45 +248,45 @@ void Canvas::run()
 {
     auto update = [](float){};
     Controller controller;
-    mImplementation->canvasImpl.run(*this, mImplementation->assets, mImplementation->imguiRtt, update, controller);
+    mImplPtr->canvasImpl.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update)
 {
     Controller controller;
-    mImplementation->canvasImpl.run(*this, mImplementation->assets, mImplementation->imguiRtt, update, controller);
+    mImplPtr->canvasImpl.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update, Controller& controller)
 {
-    mImplementation->canvasImpl.run(*this, mImplementation->assets, mImplementation->imguiRtt, update, controller);
+    mImplPtr->canvasImpl.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update, Controller& controller)
 {
-    mImplementation->canvasImpl.tick(*this, mImplementation->assets, mImplementation->imguiRtt, deltaTime, update, controller);
+    mImplPtr->canvasImpl.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update)
 {
     Controller controller;
-    mImplementation->canvasImpl.tick(*this, mImplementation->assets, mImplementation->imguiRtt, deltaTime, update, controller);
+    mImplPtr->canvasImpl.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime)
 {
     Controller controller;
-    mImplementation->canvasImpl.tick(*this, mImplementation->assets, mImplementation->imguiRtt, deltaTime, [](float){}, controller);
+    mImplPtr->canvasImpl.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, [](float){}, controller);
 }
 
 void Canvas::close()
 {
-    mImplementation->canvasImpl.close();
+    mImplPtr->canvasImpl.close();
 }
 
 DirectTexture Canvas::takeScreenshot() const
 {
-    return mImplementation->canvasImpl.takeScreenshot();
+    return mImplPtr->canvasImpl.takeScreenshot();
 }
 
 }

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -13,17 +13,17 @@ namespace Nothofagus
  * @struct Canvas::Implementation
  * @brief Single nested pimpl holding every internal collaborator by value.
  *        Owning a single Implementation struct lets `canvas.h` expose only this
- *        one nested forward declaration — `Nothofagus::CanvasImpl`,
+ *        one nested forward declaration — `Nothofagus::FrameRunner`,
  *        `Nothofagus::AssetRegistry`, and `Nothofagus::ImguiRttManager` never
  *        appear in the public header.
  *
  * Member declaration order = construction order:
- *   `canvasImpl` first (builds mBackend, creates window, init ImGui)
- *   → `assets` (binds to canvasImpl.backend())
- *   → `imguiRtt` (binds to canvasImpl.backend() and assets.renderTargets()).
+ *   `frameRunner` first (builds mBackend, creates window, init ImGui)
+ *   → `assets` (binds to frameRunner.backend())
+ *   → `imguiRtt` (binds to frameRunner.backend() and assets.renderTargets()).
  *
  * Reverse-destruction matches the GPU teardown sequence (ImGui RTT contexts
- * → asset GPU handles → ~CanvasImpl runs mBackend.shutdown()).
+ * → asset GPU handles → ~FrameRunner runs mBackend.shutdown()).
  */
 struct Canvas::Implementation
 {
@@ -34,19 +34,19 @@ struct Canvas::Implementation
         const unsigned int pixelSize,
         const float imguiFontSize,
         bool headless)
-        : canvasImpl(screenSize, title, clearColor, pixelSize, headless),
-          assets(canvasImpl.backend()),
-          imguiRtt(canvasImpl.backend(), assets.renderTargets(),
+        : frameRunner(screenSize, title, clearColor, pixelSize, headless),
+          assets(frameRunner.backend()),
+          imguiRtt(frameRunner.backend(), assets.renderTargets(),
                    assets_Roboto_VariableFont_wdth_wght_ttf,
                    assets_Roboto_VariableFont_wdth_wght_ttf_len,
                    imguiFontSize)
     {
         // Main HiDPI font bake — needs the backend's ImGui renderer to be live,
-        // which it is once CanvasImpl's ctor has returned.
-        imguiRtt.fonts().initialize(canvasImpl.contentScale());
+        // which it is once FrameRunner's ctor has returned.
+        imguiRtt.fonts().initialize(frameRunner.contentScale());
     }
 
-    CanvasImpl       canvasImpl;
+    FrameRunner       frameRunner;
     AssetRegistry    assets;
     ImguiRttManager  imguiRtt;
 };
@@ -69,27 +69,27 @@ Canvas::~Canvas()
     // GPU resources must be freed while the backend is still alive. Drain
     // imguiRtt and assets explicitly here; the by-value members inside
     // Implementation then destroy in reverse declaration order
-    // (imguiRtt → assets → canvasImpl, where the last one shuts the backend down).
+    // (imguiRtt → assets → frameRunner, where the last one shuts the backend down).
     mImplPtr->imguiRtt.releaseAll();
     mImplPtr->assets.freeAllGpuResources();
 }
 
 // ---------------------------------------------------------------------------
-// Window / display — forward to CanvasImpl
+// Window / display — forward to FrameRunner
 // ---------------------------------------------------------------------------
 
-std::size_t Canvas::getCurrentMonitor() const                   { return mImplPtr->canvasImpl.getCurrentMonitor(); }
-bool Canvas::isFullscreen() const                               { return mImplPtr->canvasImpl.isFullscreen(); }
-void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mImplPtr->canvasImpl.setFullScreenOnMonitor(monitor); }
-void Canvas::setWindowed()                                       { mImplPtr->canvasImpl.setWindowed(); }
-const ScreenSize& Canvas::screenSize() const                    { return mImplPtr->canvasImpl.screenSize(); }
-void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplPtr->canvasImpl.setScreenSize(screenSize); }
-void Canvas::setClearColor(glm::vec3 clearColor)                { mImplPtr->canvasImpl.setClearColor(clearColor); }
-void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplPtr->canvasImpl.setAutoRemoveUnusedTextures(enabled); }
-void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplPtr->canvasImpl.setAutoRemoveUnusedMeshes(enabled); }
-void Canvas::setWindowTitle(const std::string& title)           { mImplPtr->canvasImpl.setWindowTitle(title); }
-ScreenSize Canvas::windowSize() const                            { return mImplPtr->canvasImpl.windowSize(); }
-ViewportRect Canvas::gameViewport() const                       { return mImplPtr->canvasImpl.gameViewport(); }
+std::size_t Canvas::getCurrentMonitor() const                   { return mImplPtr->frameRunner.getCurrentMonitor(); }
+bool Canvas::isFullscreen() const                               { return mImplPtr->frameRunner.isFullscreen(); }
+void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mImplPtr->frameRunner.setFullScreenOnMonitor(monitor); }
+void Canvas::setWindowed()                                       { mImplPtr->frameRunner.setWindowed(); }
+const ScreenSize& Canvas::screenSize() const                    { return mImplPtr->frameRunner.screenSize(); }
+void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplPtr->frameRunner.setScreenSize(screenSize); }
+void Canvas::setClearColor(glm::vec3 clearColor)                { mImplPtr->frameRunner.setClearColor(clearColor); }
+void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplPtr->frameRunner.setAutoRemoveUnusedTextures(enabled); }
+void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplPtr->frameRunner.setAutoRemoveUnusedMeshes(enabled); }
+void Canvas::setWindowTitle(const std::string& title)           { mImplPtr->frameRunner.setWindowTitle(title); }
+ScreenSize Canvas::windowSize() const                            { return mImplPtr->frameRunner.windowSize(); }
+ViewportRect Canvas::gameViewport() const                       { return mImplPtr->frameRunner.gameViewport(); }
 
 // ---------------------------------------------------------------------------
 // Bellotas — forward to AssetRegistry; remove gates against TilemapExplorer pool
@@ -99,7 +99,7 @@ BellotaId Canvas::addBellota(const Bellota& bellota)            { return mImplPt
 
 void Canvas::removeBellota(const BellotaId bellotaId)
 {
-    debugCheck(!mImplPtr->canvasImpl.isExplorerManagedBellota(bellotaId.id),
+    debugCheck(!mImplPtr->frameRunner.isExplorerManagedBellota(bellotaId.id),
         "Bellota is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot bellotas directly.");
     mImplPtr->assets.removeBellota(bellotaId);
 }
@@ -117,7 +117,7 @@ TextureId Canvas::addTexture(const Texture& texture)            { return mImplPt
 
 void Canvas::removeTexture(const TextureId textureId)
 {
-    debugCheck(!mImplPtr->canvasImpl.isExplorerManagedTexture(textureId.id),
+    debugCheck(!mImplPtr->frameRunner.isExplorerManagedTexture(textureId.id),
         "Texture is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot textures directly.");
     mImplPtr->assets.removeTexture(textureId);
 }
@@ -158,26 +158,26 @@ TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const      
 void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mImplPtr->assets.setRenderTargetClearColor(renderTargetId, clearColor); }
 
 // ---------------------------------------------------------------------------
-// Tilemaps — forward to CanvasImpl (TilemapManager lives there)
+// Tilemaps — forward to FrameRunner (TilemapManager lives there)
 // ---------------------------------------------------------------------------
 
-TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mImplPtr->canvasImpl.addTilemap(std::move(tilemap)); }
-void Canvas::removeTilemap(TilemapId tilemapId)                                            { mImplPtr->canvasImpl.removeTilemap(tilemapId); }
-Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mImplPtr->canvasImpl.tilemap(tilemapId); }
-const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mImplPtr->canvasImpl.tilemap(tilemapId); }
-TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mImplPtr->canvasImpl.addTilemapExplorer(explorer, *this); }
-void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mImplPtr->canvasImpl.removeTilemapExplorer(explorerId, *this); }
-TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mImplPtr->canvasImpl.tilemapExplorer(explorerId); }
-const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mImplPtr->canvasImpl.tilemapExplorer(explorerId); }
+TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mImplPtr->frameRunner.addTilemap(std::move(tilemap)); }
+void Canvas::removeTilemap(TilemapId tilemapId)                                            { mImplPtr->frameRunner.removeTilemap(tilemapId); }
+Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mImplPtr->frameRunner.tilemap(tilemapId); }
+const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mImplPtr->frameRunner.tilemap(tilemapId); }
+TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mImplPtr->frameRunner.addTilemapExplorer(explorer, *this); }
+void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mImplPtr->frameRunner.removeTilemapExplorer(explorerId, *this); }
+TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mImplPtr->frameRunner.tilemapExplorer(explorerId); }
+const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mImplPtr->frameRunner.tilemapExplorer(explorerId); }
 
 // ---------------------------------------------------------------------------
-// RTT pass scheduling (the queue lives on CanvasImpl; the ImGui-to-RTT
+// RTT pass scheduling (the queue lives on FrameRunner; the ImGui-to-RTT
 // scheduling lives on ImguiRttManager)
 // ---------------------------------------------------------------------------
 
 void Canvas::renderTo(RenderTargetId renderTargetId, std::vector<BellotaId> bellotaIds)
 {
-    mImplPtr->canvasImpl.renderTo(renderTargetId, std::move(bellotaIds));
+    mImplPtr->frameRunner.renderTo(renderTargetId, std::move(bellotaIds));
 }
 
 void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, ImguiDrawCallback imguiDrawCallback)
@@ -237,8 +237,8 @@ ImguiFontId Canvas::defaultImguiFontId() const
 // Stats flag
 // ---------------------------------------------------------------------------
 
-bool& Canvas::stats()                                            { return mImplPtr->canvasImpl.stats(); }
-const bool& Canvas::stats() const                                { return mImplPtr->canvasImpl.stats(); }
+bool& Canvas::stats()                                            { return mImplPtr->frameRunner.stats(); }
+const bool& Canvas::stats() const                                { return mImplPtr->frameRunner.stats(); }
 
 // ---------------------------------------------------------------------------
 // Lifecycle — thread the assets + imguiRtt managers into the frame loop
@@ -248,45 +248,45 @@ void Canvas::run()
 {
     auto update = [](float){};
     Controller controller;
-    mImplPtr->canvasImpl.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
+    mImplPtr->frameRunner.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update)
 {
     Controller controller;
-    mImplPtr->canvasImpl.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
+    mImplPtr->frameRunner.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update, Controller& controller)
 {
-    mImplPtr->canvasImpl.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
+    mImplPtr->frameRunner.run(*this, mImplPtr->assets, mImplPtr->imguiRtt, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update, Controller& controller)
 {
-    mImplPtr->canvasImpl.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, update, controller);
+    mImplPtr->frameRunner.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update)
 {
     Controller controller;
-    mImplPtr->canvasImpl.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, update, controller);
+    mImplPtr->frameRunner.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime)
 {
     Controller controller;
-    mImplPtr->canvasImpl.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, [](float){}, controller);
+    mImplPtr->frameRunner.tick(*this, mImplPtr->assets, mImplPtr->imguiRtt, deltaTime, [](float){}, controller);
 }
 
 void Canvas::close()
 {
-    mImplPtr->canvasImpl.close();
+    mImplPtr->frameRunner.close();
 }
 
 DirectTexture Canvas::takeScreenshot() const
 {
-    return mImplPtr->canvasImpl.takeScreenshot();
+    return mImplPtr->frameRunner.takeScreenshot();
 }
 
 }

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -46,7 +46,7 @@ struct Canvas::Implementation
         imguiRtt.fonts().initialize(frameRunner.contentScale());
     }
 
-    FrameRunner      rameRunner;
+    FrameRunner      frameRunner;
     AssetRegistry    assets;
     ImguiRttManager  imguiRtt;
 };

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -46,7 +46,7 @@ struct Canvas::Implementation
         imguiRtt.fonts().initialize(frameRunner.contentScale());
     }
 
-    FrameRunner       frameRunner;
+    FrameRunner      rameRunner;
     AssetRegistry    assets;
     ImguiRttManager  imguiRtt;
 };

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -1,8 +1,31 @@
 #include "canvas.h"
 #include "canvas_impl.h"
+#include "asset_registry.h"
+#include "imgui_rtt_manager.h"
+#include "check.h"
+#include "roboto_font.h"
+#include <imgui.h>
 
 namespace Nothofagus
 {
+
+/**
+ * @struct Canvas::Private
+ * @brief Single nested pimpl holding every internal collaborator. Owning a
+ *        single Private struct lets `canvas.h` expose only this one nested
+ *        forward declaration — `Nothofagus::AssetRegistry` and
+ *        `Nothofagus::ImguiRttManager` never appear in the public header.
+ *
+ * Member declaration order matches construction order; reverse-destruction
+ * matches the GPU teardown sequence (ImGui RTT contexts → asset GPU handles
+ * → ~CanvasImpl runs mBackend.shutdown()).
+ */
+struct Canvas::Private
+{
+    std::unique_ptr<CanvasImpl>       canvasImpl;
+    std::unique_ptr<AssetRegistry>    assets;
+    std::unique_ptr<ImguiRttManager>  imguiRtt;
+};
 
 Canvas::Canvas(
     const ScreenSize& screenSize,
@@ -12,348 +35,247 @@ Canvas::Canvas(
     const float imguiFontSize,
     bool headless
 )
+    : mPrivate(std::make_unique<Private>())
 {
-    mCanvasImpl = std::make_unique<CanvasImpl>(screenSize, title, clearColor, pixelSize, imguiFontSize, headless);
+    // Construction order matters: CanvasImpl builds mBackend and initializes
+    // the GPU + ImGui main context. AssetRegistry takes a reference to that
+    // backend. ImguiRttManager takes references to the backend AND the
+    // registry's RenderTargetContainer. Finally bake the main HiDPI font
+    // (needs the backend's ImGui renderer to be live).
+    mPrivate->canvasImpl = std::make_unique<CanvasImpl>(screenSize, title, clearColor, pixelSize, headless);
+    mPrivate->assets     = std::make_unique<AssetRegistry>(mPrivate->canvasImpl->backend());
+    mPrivate->imguiRtt   = std::make_unique<ImguiRttManager>(
+        mPrivate->canvasImpl->backend(),
+        mPrivate->assets->renderTargets(),
+        assets_Roboto_VariableFont_wdth_wght_ttf,
+        assets_Roboto_VariableFont_wdth_wght_ttf_len,
+        imguiFontSize);
+    mPrivate->imguiRtt->fonts().initialize(mPrivate->canvasImpl->contentScale());
 }
 
 Canvas::~Canvas()
 {
-
+    // GPU resources must be freed while the backend is still alive. Drain
+    // imguiRtt and assets explicitly here; the unique_ptrs inside Private
+    // then destroy in reverse declaration order (imguiRtt → assets →
+    // canvasImpl, where the last one shuts the backend down).
+    mPrivate->imguiRtt->releaseAll();
+    mPrivate->assets->freeAllGpuResources();
 }
 
-std::size_t Canvas::getCurrentMonitor() const
-{
-    return mCanvasImpl->getCurrentMonitor();;
-}
+// ---------------------------------------------------------------------------
+// Window / display — forward to CanvasImpl
+// ---------------------------------------------------------------------------
 
-bool Canvas::isFullscreen() const
-{
-    return mCanvasImpl->isFullscreen();
-}
+std::size_t Canvas::getCurrentMonitor() const                   { return mPrivate->canvasImpl->getCurrentMonitor(); }
+bool Canvas::isFullscreen() const                               { return mPrivate->canvasImpl->isFullscreen(); }
+void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mPrivate->canvasImpl->setFullScreenOnMonitor(monitor); }
+void Canvas::setWindowed()                                       { mPrivate->canvasImpl->setWindowed(); }
+const ScreenSize& Canvas::screenSize() const                    { return mPrivate->canvasImpl->screenSize(); }
+void Canvas::setScreenSize(const ScreenSize& screenSize)        { mPrivate->canvasImpl->setScreenSize(screenSize); }
+void Canvas::setClearColor(glm::vec3 clearColor)                { mPrivate->canvasImpl->setClearColor(clearColor); }
+void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mPrivate->canvasImpl->setAutoRemoveUnusedTextures(enabled); }
+void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mPrivate->canvasImpl->setAutoRemoveUnusedMeshes(enabled); }
+void Canvas::setWindowTitle(const std::string& title)           { mPrivate->canvasImpl->setWindowTitle(title); }
+ScreenSize Canvas::windowSize() const                            { return mPrivate->canvasImpl->windowSize(); }
+ViewportRect Canvas::gameViewport() const                       { return mPrivate->canvasImpl->gameViewport(); }
 
-void Canvas::setFullScreenOnMonitor(std::size_t monitor)
-{
-    mCanvasImpl->setFullScreenOnMonitor(monitor);
-}
+// ---------------------------------------------------------------------------
+// Bellotas — forward to AssetRegistry; remove gates against TilemapExplorer pool
+// ---------------------------------------------------------------------------
 
-void Canvas::setWindowed()
-{
-    mCanvasImpl->setWindowed();
-}
-
-const ScreenSize& Canvas::screenSize() const
-{
-    return mCanvasImpl->screenSize();
-}
-
-void Canvas::setScreenSize(const ScreenSize& screenSize)
-{
-    mCanvasImpl->setScreenSize(screenSize);
-}
-
-void Canvas::setClearColor(glm::vec3 clearColor)
-{
-    mCanvasImpl->setClearColor(clearColor);
-}
-
-void Canvas::setAutoRemoveUnusedTextures(bool enabled)
-{
-    mCanvasImpl->setAutoRemoveUnusedTextures(enabled);
-}
-
-void Canvas::setAutoRemoveUnusedMeshes(bool enabled)
-{
-    mCanvasImpl->setAutoRemoveUnusedMeshes(enabled);
-}
-
-void Canvas::setWindowTitle(const std::string& title)
-{
-    mCanvasImpl->setWindowTitle(title);
-}
-
-ScreenSize Canvas::windowSize() const
-{
-    return mCanvasImpl->windowSize();
-}
-
-ViewportRect Canvas::gameViewport() const
-{
-    return mCanvasImpl->gameViewport();
-}
-
-BellotaId Canvas::addBellota(const Bellota& bellota)
-{
-    return mCanvasImpl->addBellota(bellota);
-}
+BellotaId Canvas::addBellota(const Bellota& bellota)            { return mPrivate->assets->addBellota(bellota); }
 
 void Canvas::removeBellota(const BellotaId bellotaId)
 {
-    mCanvasImpl->removeBellota(bellotaId);
+    debugCheck(!mPrivate->canvasImpl->isExplorerManagedBellota(bellotaId.id),
+        "Bellota is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot bellotas directly.");
+    mPrivate->assets->removeBellota(bellotaId);
 }
 
-TextureId Canvas::addTexture(const Texture& texture)
-{
-    return mCanvasImpl->addTexture(texture);
-}
+Bellota& Canvas::bellota(BellotaId bellotaId)                   { return mPrivate->assets->bellota(bellotaId); }
+const Bellota& Canvas::bellota(BellotaId bellotaId) const       { return mPrivate->assets->bellota(bellotaId); }
+void Canvas::setTint(const BellotaId bellotaId, const Tint& tint) { mPrivate->assets->setTint(bellotaId, tint); }
+void Canvas::removeTint(const BellotaId bellotaId)              { mPrivate->assets->removeTint(bellotaId); }
+
+// ---------------------------------------------------------------------------
+// Textures — forward to AssetRegistry; remove gates against TilemapExplorer pool
+// ---------------------------------------------------------------------------
+
+TextureId Canvas::addTexture(const Texture& texture)            { return mPrivate->assets->addTexture(texture); }
 
 void Canvas::removeTexture(const TextureId textureId)
 {
-    mCanvasImpl->removeTexture(textureId);
+    debugCheck(!mPrivate->canvasImpl->isExplorerManagedTexture(textureId.id),
+        "Texture is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot textures directly.");
+    mPrivate->assets->removeTexture(textureId);
 }
 
-void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)
-{
-    mCanvasImpl->setTexture(bellotaId, textureId);
-}
+void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)            { mPrivate->assets->setTexture(bellotaId, textureId); }
+void Canvas::markTextureAsDirty(const TextureId textureId)                                { mPrivate->assets->markTextureAsDirty(textureId); }
+void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)       { mPrivate->assets->setTextureMinFilter(textureId, mode); }
+void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)       { mPrivate->assets->setTextureMagFilter(textureId, mode); }
+Texture& Canvas::texture(TextureId textureId)                                             { return mPrivate->assets->texture(textureId); }
+const Texture& Canvas::texture(TextureId textureId) const                                 { return mPrivate->assets->texture(textureId); }
 
-void Canvas::markTextureAsDirty(const TextureId textureId)
-{
-    mCanvasImpl->markTextureAsDirty(textureId);
-}
+// ---------------------------------------------------------------------------
+// Meshes — forward to AssetRegistry
+// ---------------------------------------------------------------------------
 
-void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)
-{
-    mCanvasImpl->setTextureMinFilter(textureId, mode);
-}
+MeshId Canvas::addMesh(const Mesh& mesh)                                                  { return mPrivate->assets->addMesh(mesh); }
+MeshId Canvas::addMesh(Mesh&& mesh)                                                       { return mPrivate->assets->addMesh(std::move(mesh)); }
+void Canvas::removeMesh(MeshId meshId)                                                    { mPrivate->assets->removeMesh(meshId); }
+void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)                      { mPrivate->assets->setMesh(bellotaId, meshId); }
+const Mesh& Canvas::mesh(MeshId meshId) const                                             { return mPrivate->assets->mesh(meshId); }
+const Mesh& Canvas::mesh(BellotaId bellotaId) const                                       { return mPrivate->assets->mesh(bellotaId); }
 
-void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)
-{
-    mCanvasImpl->setTextureMagFilter(textureId, mode);
-}
+// ---------------------------------------------------------------------------
+// Render targets — forward to AssetRegistry; remove tears down the per-RTT
+// ImGui secondary context first (its backend resources are tied to the RTT
+// render pass / FBO that the registry is about to free).
+// ---------------------------------------------------------------------------
 
-MeshId Canvas::addMesh(const Mesh& mesh)
-{
-    return mCanvasImpl->addMesh(mesh);
-}
-
-MeshId Canvas::addMesh(Mesh&& mesh)
-{
-    return mCanvasImpl->addMesh(std::move(mesh));
-}
-
-void Canvas::removeMesh(MeshId meshId)
-{
-    mCanvasImpl->removeMesh(meshId);
-}
-
-void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)
-{
-    mCanvasImpl->setMesh(bellotaId, meshId);
-}
-
-const Mesh& Canvas::mesh(MeshId meshId) const
-{
-    return mCanvasImpl->mesh(meshId);
-}
-
-const Mesh& Canvas::mesh(BellotaId bellotaId) const
-{
-    return mCanvasImpl->mesh(bellotaId);
-}
-
-RenderTargetId Canvas::addRenderTarget(ScreenSize size)
-{
-    return mCanvasImpl->addRenderTarget(size);
-}
+RenderTargetId Canvas::addRenderTarget(ScreenSize size)                                   { return mPrivate->assets->addRenderTarget(size); }
 
 void Canvas::removeRenderTarget(RenderTargetId renderTargetId)
 {
-    mCanvasImpl->removeRenderTarget(renderTargetId);
+    mPrivate->imguiRtt->releaseContext(renderTargetId);
+    mPrivate->assets->removeRenderTarget(renderTargetId);
 }
 
-TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const
-{
-    return mCanvasImpl->renderTargetTexture(renderTargetId);
-}
+TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const                { return mPrivate->assets->renderTargetTexture(renderTargetId); }
+void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mPrivate->assets->setRenderTargetClearColor(renderTargetId, clearColor); }
 
-TilemapId Canvas::addTilemap(Tilemap tilemap)
-{
-    return mCanvasImpl->addTilemap(std::move(tilemap));
-}
+// ---------------------------------------------------------------------------
+// Tilemaps — forward to CanvasImpl (TilemapManager lives there)
+// ---------------------------------------------------------------------------
 
-void Canvas::removeTilemap(TilemapId tilemapId)
-{
-    mCanvasImpl->removeTilemap(tilemapId);
-}
+TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mPrivate->canvasImpl->addTilemap(std::move(tilemap)); }
+void Canvas::removeTilemap(TilemapId tilemapId)                                            { mPrivate->canvasImpl->removeTilemap(tilemapId); }
+Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mPrivate->canvasImpl->tilemap(tilemapId); }
+const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mPrivate->canvasImpl->tilemap(tilemapId); }
+TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mPrivate->canvasImpl->addTilemapExplorer(explorer, *this); }
+void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mPrivate->canvasImpl->removeTilemapExplorer(explorerId, *this); }
+TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mPrivate->canvasImpl->tilemapExplorer(explorerId); }
+const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mPrivate->canvasImpl->tilemapExplorer(explorerId); }
 
-Tilemap& Canvas::tilemap(TilemapId tilemapId)
-{
-    return mCanvasImpl->tilemap(tilemapId);
-}
-
-const Tilemap& Canvas::tilemap(TilemapId tilemapId) const
-{
-    return mCanvasImpl->tilemap(tilemapId);
-}
-
-TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)
-{
-    return mCanvasImpl->addTilemapExplorer(explorer, *this);
-}
-
-void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)
-{
-    mCanvasImpl->removeTilemapExplorer(explorerId, *this);
-}
-
-TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)
-{
-    return mCanvasImpl->tilemapExplorer(explorerId);
-}
-
-const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const
-{
-    return mCanvasImpl->tilemapExplorer(explorerId);
-}
+// ---------------------------------------------------------------------------
+// RTT pass scheduling (the queue lives on CanvasImpl; the ImGui-to-RTT
+// scheduling lives on ImguiRttManager)
+// ---------------------------------------------------------------------------
 
 void Canvas::renderTo(RenderTargetId renderTargetId, std::vector<BellotaId> bellotaIds)
 {
-    mCanvasImpl->renderTo(renderTargetId, std::move(bellotaIds));
+    mPrivate->canvasImpl->renderTo(renderTargetId, std::move(bellotaIds));
 }
 
 void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, ImguiDrawCallback imguiDrawCallback)
 {
-    mCanvasImpl->renderImguiTo(renderTargetId, fontId, std::move(imguiDrawCallback));
+    // Wrap the user's callback with auto-push/pop of fontId. Graceful fallback:
+    // if the bake is still pending or the id was removed, the callback runs
+    // without an explicit push (the secondary-context default stays in effect).
+    mPrivate->imguiRtt->enqueue(renderTargetId,
+        [this, fontId, cb = std::move(imguiDrawCallback)] {
+            if (isImguiFontReady(fontId))
+            {
+                pushImguiFont(fontId);
+                cb();
+                popImguiFont();
+            }
+            else
+            {
+                cb();
+            }
+        });
 }
 
-ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange)
-{
-    return mCanvasImpl->addImguiFontSource(ttfBytes, glyphRange);
-}
+// ---------------------------------------------------------------------------
+// ImGui fonts — forward to mPrivate->imguiRtt->fonts() (or wrap in imgui.h calls)
+// ---------------------------------------------------------------------------
 
-void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)
-{
-    mCanvasImpl->removeImguiFontSource(sourceId);
-}
-
-ImguiFontSourceId Canvas::defaultImguiFontSourceId() const
-{
-    return mCanvasImpl->defaultImguiFontSourceId();
-}
-
-ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)
-{
-    return mCanvasImpl->bakeImguiFont(sourceId, sizePx);
-}
-
-void Canvas::removeImguiFont(ImguiFontId id)
-{
-    mCanvasImpl->removeImguiFont(id);
-}
-
-bool Canvas::isImguiFontReady(ImguiFontId id) const
-{
-    return mCanvasImpl->isImguiFontReady(id);
-}
-
-ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const
-{
-    return mCanvasImpl->getImguiFontPtr(id);
-}
+ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mPrivate->imguiRtt->fonts().addSource(ttfBytes, glyphRange); }
+void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)                                          { mPrivate->imguiRtt->fonts().removeSource(sourceId); }
+ImguiFontSourceId Canvas::defaultImguiFontSourceId() const                                              { return mPrivate->imguiRtt->fonts().defaultSourceId(); }
+ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                             { return mPrivate->imguiRtt->fonts().bake(sourceId, sizePx); }
+void Canvas::removeImguiFont(ImguiFontId id)                                                            { mPrivate->imguiRtt->fonts().remove(id); }
+bool Canvas::isImguiFontReady(ImguiFontId id) const                                                     { return mPrivate->imguiRtt->fonts().get(id) != nullptr; }
+ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const                                                   { return mPrivate->imguiRtt->fonts().get(id); }
 
 void Canvas::pushImguiFont(ImguiFontId id)
 {
-    mCanvasImpl->pushImguiFont(id);
+    ImFont* font = getImguiFontPtr(id);
+    debugCheck(font != nullptr,
+        "Canvas::pushImguiFont: id is not registered or its bake is still pending — guard with isImguiFontReady()");
+    ImGui::PushFont(font);
 }
 
 void Canvas::popImguiFont()
 {
-    mCanvasImpl->popImguiFont();
+    ImGui::PopFont();
 }
 
 ImguiFontId Canvas::defaultImguiFontId() const
 {
-    return mCanvasImpl->defaultImguiFontId();
+    auto idOpt = mPrivate->imguiRtt->fonts().defaultFontId();
+    debugCheck(idOpt.has_value(),
+        "Canvas::defaultImguiFontId: no default font registered (Canvas ctor seeds this — should never fire)");
+    return *idOpt;
 }
 
-void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor)
-{
-    mCanvasImpl->setRenderTargetClearColor(renderTargetId, clearColor);
-}
+// ---------------------------------------------------------------------------
+// Stats flag
+// ---------------------------------------------------------------------------
 
-void Canvas::setTint(const BellotaId bellotaId, const Tint& tint)
-{
-    mCanvasImpl->setTint(bellotaId, tint);
-}
+bool& Canvas::stats()                                            { return mPrivate->canvasImpl->stats(); }
+const bool& Canvas::stats() const                                { return mPrivate->canvasImpl->stats(); }
 
-void Canvas::removeTint(const BellotaId bellotaId)
-{
-    mCanvasImpl->removeTint(bellotaId);
-}
-
-Bellota& Canvas::bellota(BellotaId bellotaId)
-{
-    return mCanvasImpl->bellota(bellotaId);
-}
-
-const Bellota& Canvas::bellota(BellotaId bellotaId) const
-{
-    return mCanvasImpl->bellota(bellotaId);
-}
-
-Texture& Canvas::texture(TextureId textureId)
-{
-    return mCanvasImpl->texture(textureId);
-}
-
-const Texture& Canvas::texture(TextureId textureId) const
-{
-    return mCanvasImpl->texture(textureId);
-}
-
-bool& Canvas::stats()
-{
-    return mCanvasImpl->stats();
-}
-
-const bool& Canvas::stats() const
-{
-    return mCanvasImpl->stats();
-}
+// ---------------------------------------------------------------------------
+// Lifecycle — thread the assets + imguiRtt managers into the frame loop
+// ---------------------------------------------------------------------------
 
 void Canvas::run()
 {
-    auto update = [](float deltaTime){};
+    auto update = [](float){};
     Controller controller;
-    mCanvasImpl->run(*this, update, controller);
+    mPrivate->canvasImpl->run(*this, *mPrivate->assets, *mPrivate->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update)
 {
     Controller controller;
-    mCanvasImpl->run(*this, update, controller);
+    mPrivate->canvasImpl->run(*this, *mPrivate->assets, *mPrivate->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update, Controller& controller)
 {
-    mCanvasImpl->run(*this, update, controller);
+    mPrivate->canvasImpl->run(*this, *mPrivate->assets, *mPrivate->imguiRtt, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update, Controller& controller)
 {
-    mCanvasImpl->tick(*this, deltaTime, update, controller);
+    mPrivate->canvasImpl->tick(*this, *mPrivate->assets, *mPrivate->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update)
 {
     Controller controller;
-    mCanvasImpl->tick(*this, deltaTime, update, controller);
+    mPrivate->canvasImpl->tick(*this, *mPrivate->assets, *mPrivate->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime)
 {
     Controller controller;
-    mCanvasImpl->tick(*this, deltaTime, [](float){}, controller);
+    mPrivate->canvasImpl->tick(*this, *mPrivate->assets, *mPrivate->imguiRtt, deltaTime, [](float){}, controller);
 }
 
 void Canvas::close()
 {
-    mCanvasImpl->close();
+    mPrivate->canvasImpl->close();
 }
 
 DirectTexture Canvas::takeScreenshot() const
 {
-    return mCanvasImpl->takeScreenshot();
+    return mPrivate->canvasImpl->takeScreenshot();
 }
 
 }

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -11,20 +11,44 @@ namespace Nothofagus
 
 /**
  * @struct Canvas::Implementation
- * @brief Single nested pimpl holding every internal collaborator. Owning a
- *        single Implementation struct lets `canvas.h` expose only this one nested
- *        forward declaration — `Nothofagus::AssetRegistry` and
- *        `Nothofagus::ImguiRttManager` never appear in the public header.
+ * @brief Single nested pimpl holding every internal collaborator by value.
+ *        Owning a single Implementation struct lets `canvas.h` expose only this
+ *        one nested forward declaration — `Nothofagus::CanvasImpl`,
+ *        `Nothofagus::AssetRegistry`, and `Nothofagus::ImguiRttManager` never
+ *        appear in the public header.
  *
- * Member declaration order matches construction order; reverse-destruction
- * matches the GPU teardown sequence (ImGui RTT contexts → asset GPU handles
- * → ~CanvasImpl runs mBackend.shutdown()).
+ * Member declaration order = construction order:
+ *   `canvasImpl` first (builds mBackend, creates window, init ImGui)
+ *   → `assets` (binds to canvasImpl.backend())
+ *   → `imguiRtt` (binds to canvasImpl.backend() and assets.renderTargets()).
+ *
+ * Reverse-destruction matches the GPU teardown sequence (ImGui RTT contexts
+ * → asset GPU handles → ~CanvasImpl runs mBackend.shutdown()).
  */
 struct Canvas::Implementation
 {
-    std::unique_ptr<CanvasImpl>       canvasImpl;
-    std::unique_ptr<AssetRegistry>    assets;
-    std::unique_ptr<ImguiRttManager>  imguiRtt;
+    Implementation(
+        const ScreenSize& screenSize,
+        const std::string& title,
+        const glm::vec3 clearColor,
+        const unsigned int pixelSize,
+        const float imguiFontSize,
+        bool headless)
+        : canvasImpl(screenSize, title, clearColor, pixelSize, headless),
+          assets(canvasImpl.backend()),
+          imguiRtt(canvasImpl.backend(), assets.renderTargets(),
+                   assets_Roboto_VariableFont_wdth_wght_ttf,
+                   assets_Roboto_VariableFont_wdth_wght_ttf_len,
+                   imguiFontSize)
+    {
+        // Main HiDPI font bake — needs the backend's ImGui renderer to be live,
+        // which it is once CanvasImpl's ctor has returned.
+        imguiRtt.fonts().initialize(canvasImpl.contentScale());
+    }
+
+    CanvasImpl       canvasImpl;
+    AssetRegistry    assets;
+    ImguiRttManager  imguiRtt;
 };
 
 Canvas::Canvas(
@@ -35,99 +59,86 @@ Canvas::Canvas(
     const float imguiFontSize,
     bool headless
 )
-    : mImplementation(std::make_unique<Implementation>())
+    : mImplementation(std::make_unique<Implementation>(
+          screenSize, title, clearColor, pixelSize, imguiFontSize, headless))
 {
-    // Construction order matters: CanvasImpl builds mBackend and initializes
-    // the GPU + ImGui main context. AssetRegistry takes a reference to that
-    // backend. ImguiRttManager takes references to the backend AND the
-    // registry's RenderTargetContainer. Finally bake the main HiDPI font
-    // (needs the backend's ImGui renderer to be live).
-    mImplementation->canvasImpl = std::make_unique<CanvasImpl>(screenSize, title, clearColor, pixelSize, headless);
-    mImplementation->assets     = std::make_unique<AssetRegistry>(mImplementation->canvasImpl->backend());
-    mImplementation->imguiRtt   = std::make_unique<ImguiRttManager>(
-        mImplementation->canvasImpl->backend(),
-        mImplementation->assets->renderTargets(),
-        assets_Roboto_VariableFont_wdth_wght_ttf,
-        assets_Roboto_VariableFont_wdth_wght_ttf_len,
-        imguiFontSize);
-    mImplementation->imguiRtt->fonts().initialize(mImplementation->canvasImpl->contentScale());
 }
 
 Canvas::~Canvas()
 {
     // GPU resources must be freed while the backend is still alive. Drain
-    // imguiRtt and assets explicitly here; the unique_ptrs inside Implementation
-    // then destroy in reverse declaration order (imguiRtt → assets →
-    // canvasImpl, where the last one shuts the backend down).
-    mImplementation->imguiRtt->releaseAll();
-    mImplementation->assets->freeAllGpuResources();
+    // imguiRtt and assets explicitly here; the by-value members inside
+    // Implementation then destroy in reverse declaration order
+    // (imguiRtt → assets → canvasImpl, where the last one shuts the backend down).
+    mImplementation->imguiRtt.releaseAll();
+    mImplementation->assets.freeAllGpuResources();
 }
 
 // ---------------------------------------------------------------------------
 // Window / display — forward to CanvasImpl
 // ---------------------------------------------------------------------------
 
-std::size_t Canvas::getCurrentMonitor() const                   { return mImplementation->canvasImpl->getCurrentMonitor(); }
-bool Canvas::isFullscreen() const                               { return mImplementation->canvasImpl->isFullscreen(); }
-void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mImplementation->canvasImpl->setFullScreenOnMonitor(monitor); }
-void Canvas::setWindowed()                                       { mImplementation->canvasImpl->setWindowed(); }
-const ScreenSize& Canvas::screenSize() const                    { return mImplementation->canvasImpl->screenSize(); }
-void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplementation->canvasImpl->setScreenSize(screenSize); }
-void Canvas::setClearColor(glm::vec3 clearColor)                { mImplementation->canvasImpl->setClearColor(clearColor); }
-void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplementation->canvasImpl->setAutoRemoveUnusedTextures(enabled); }
-void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplementation->canvasImpl->setAutoRemoveUnusedMeshes(enabled); }
-void Canvas::setWindowTitle(const std::string& title)           { mImplementation->canvasImpl->setWindowTitle(title); }
-ScreenSize Canvas::windowSize() const                            { return mImplementation->canvasImpl->windowSize(); }
-ViewportRect Canvas::gameViewport() const                       { return mImplementation->canvasImpl->gameViewport(); }
+std::size_t Canvas::getCurrentMonitor() const                   { return mImplementation->canvasImpl.getCurrentMonitor(); }
+bool Canvas::isFullscreen() const                               { return mImplementation->canvasImpl.isFullscreen(); }
+void Canvas::setFullScreenOnMonitor(std::size_t monitor)        { mImplementation->canvasImpl.setFullScreenOnMonitor(monitor); }
+void Canvas::setWindowed()                                       { mImplementation->canvasImpl.setWindowed(); }
+const ScreenSize& Canvas::screenSize() const                    { return mImplementation->canvasImpl.screenSize(); }
+void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplementation->canvasImpl.setScreenSize(screenSize); }
+void Canvas::setClearColor(glm::vec3 clearColor)                { mImplementation->canvasImpl.setClearColor(clearColor); }
+void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplementation->canvasImpl.setAutoRemoveUnusedTextures(enabled); }
+void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplementation->canvasImpl.setAutoRemoveUnusedMeshes(enabled); }
+void Canvas::setWindowTitle(const std::string& title)           { mImplementation->canvasImpl.setWindowTitle(title); }
+ScreenSize Canvas::windowSize() const                            { return mImplementation->canvasImpl.windowSize(); }
+ViewportRect Canvas::gameViewport() const                       { return mImplementation->canvasImpl.gameViewport(); }
 
 // ---------------------------------------------------------------------------
 // Bellotas — forward to AssetRegistry; remove gates against TilemapExplorer pool
 // ---------------------------------------------------------------------------
 
-BellotaId Canvas::addBellota(const Bellota& bellota)            { return mImplementation->assets->addBellota(bellota); }
+BellotaId Canvas::addBellota(const Bellota& bellota)            { return mImplementation->assets.addBellota(bellota); }
 
 void Canvas::removeBellota(const BellotaId bellotaId)
 {
-    debugCheck(!mImplementation->canvasImpl->isExplorerManagedBellota(bellotaId.id),
+    debugCheck(!mImplementation->canvasImpl.isExplorerManagedBellota(bellotaId.id),
         "Bellota is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot bellotas directly.");
-    mImplementation->assets->removeBellota(bellotaId);
+    mImplementation->assets.removeBellota(bellotaId);
 }
 
-Bellota& Canvas::bellota(BellotaId bellotaId)                   { return mImplementation->assets->bellota(bellotaId); }
-const Bellota& Canvas::bellota(BellotaId bellotaId) const       { return mImplementation->assets->bellota(bellotaId); }
-void Canvas::setTint(const BellotaId bellotaId, const Tint& tint) { mImplementation->assets->setTint(bellotaId, tint); }
-void Canvas::removeTint(const BellotaId bellotaId)              { mImplementation->assets->removeTint(bellotaId); }
+Bellota& Canvas::bellota(BellotaId bellotaId)                   { return mImplementation->assets.bellota(bellotaId); }
+const Bellota& Canvas::bellota(BellotaId bellotaId) const       { return mImplementation->assets.bellota(bellotaId); }
+void Canvas::setTint(const BellotaId bellotaId, const Tint& tint) { mImplementation->assets.setTint(bellotaId, tint); }
+void Canvas::removeTint(const BellotaId bellotaId)              { mImplementation->assets.removeTint(bellotaId); }
 
 // ---------------------------------------------------------------------------
 // Textures — forward to AssetRegistry; remove gates against TilemapExplorer pool
 // ---------------------------------------------------------------------------
 
-TextureId Canvas::addTexture(const Texture& texture)            { return mImplementation->assets->addTexture(texture); }
+TextureId Canvas::addTexture(const Texture& texture)            { return mImplementation->assets.addTexture(texture); }
 
 void Canvas::removeTexture(const TextureId textureId)
 {
-    debugCheck(!mImplementation->canvasImpl->isExplorerManagedTexture(textureId.id),
+    debugCheck(!mImplementation->canvasImpl.isExplorerManagedTexture(textureId.id),
         "Texture is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot textures directly.");
-    mImplementation->assets->removeTexture(textureId);
+    mImplementation->assets.removeTexture(textureId);
 }
 
-void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)            { mImplementation->assets->setTexture(bellotaId, textureId); }
-void Canvas::markTextureAsDirty(const TextureId textureId)                                { mImplementation->assets->markTextureAsDirty(textureId); }
-void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets->setTextureMinFilter(textureId, mode); }
-void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets->setTextureMagFilter(textureId, mode); }
-Texture& Canvas::texture(TextureId textureId)                                             { return mImplementation->assets->texture(textureId); }
-const Texture& Canvas::texture(TextureId textureId) const                                 { return mImplementation->assets->texture(textureId); }
+void Canvas::setTexture(const BellotaId bellotaId, const TextureId textureId)            { mImplementation->assets.setTexture(bellotaId, textureId); }
+void Canvas::markTextureAsDirty(const TextureId textureId)                                { mImplementation->assets.markTextureAsDirty(textureId); }
+void Canvas::setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets.setTextureMinFilter(textureId, mode); }
+void Canvas::setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)       { mImplementation->assets.setTextureMagFilter(textureId, mode); }
+Texture& Canvas::texture(TextureId textureId)                                             { return mImplementation->assets.texture(textureId); }
+const Texture& Canvas::texture(TextureId textureId) const                                 { return mImplementation->assets.texture(textureId); }
 
 // ---------------------------------------------------------------------------
 // Meshes — forward to AssetRegistry
 // ---------------------------------------------------------------------------
 
-MeshId Canvas::addMesh(const Mesh& mesh)                                                  { return mImplementation->assets->addMesh(mesh); }
-MeshId Canvas::addMesh(Mesh&& mesh)                                                       { return mImplementation->assets->addMesh(std::move(mesh)); }
-void Canvas::removeMesh(MeshId meshId)                                                    { mImplementation->assets->removeMesh(meshId); }
-void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)                      { mImplementation->assets->setMesh(bellotaId, meshId); }
-const Mesh& Canvas::mesh(MeshId meshId) const                                             { return mImplementation->assets->mesh(meshId); }
-const Mesh& Canvas::mesh(BellotaId bellotaId) const                                       { return mImplementation->assets->mesh(bellotaId); }
+MeshId Canvas::addMesh(const Mesh& mesh)                                                  { return mImplementation->assets.addMesh(mesh); }
+MeshId Canvas::addMesh(Mesh&& mesh)                                                       { return mImplementation->assets.addMesh(std::move(mesh)); }
+void Canvas::removeMesh(MeshId meshId)                                                    { mImplementation->assets.removeMesh(meshId); }
+void Canvas::setMesh(const BellotaId bellotaId, const MeshId meshId)                      { mImplementation->assets.setMesh(bellotaId, meshId); }
+const Mesh& Canvas::mesh(MeshId meshId) const                                             { return mImplementation->assets.mesh(meshId); }
+const Mesh& Canvas::mesh(BellotaId bellotaId) const                                       { return mImplementation->assets.mesh(bellotaId); }
 
 // ---------------------------------------------------------------------------
 // Render targets — forward to AssetRegistry; remove tears down the per-RTT
@@ -135,29 +146,29 @@ const Mesh& Canvas::mesh(BellotaId bellotaId) const                             
 // render pass / FBO that the registry is about to free).
 // ---------------------------------------------------------------------------
 
-RenderTargetId Canvas::addRenderTarget(ScreenSize size)                                   { return mImplementation->assets->addRenderTarget(size); }
+RenderTargetId Canvas::addRenderTarget(ScreenSize size)                                   { return mImplementation->assets.addRenderTarget(size); }
 
 void Canvas::removeRenderTarget(RenderTargetId renderTargetId)
 {
-    mImplementation->imguiRtt->releaseContext(renderTargetId);
-    mImplementation->assets->removeRenderTarget(renderTargetId);
+    mImplementation->imguiRtt.releaseContext(renderTargetId);
+    mImplementation->assets.removeRenderTarget(renderTargetId);
 }
 
-TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const                { return mImplementation->assets->renderTargetTexture(renderTargetId); }
-void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mImplementation->assets->setRenderTargetClearColor(renderTargetId, clearColor); }
+TextureId Canvas::renderTargetTexture(RenderTargetId renderTargetId) const                { return mImplementation->assets.renderTargetTexture(renderTargetId); }
+void Canvas::setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor) { mImplementation->assets.setRenderTargetClearColor(renderTargetId, clearColor); }
 
 // ---------------------------------------------------------------------------
 // Tilemaps — forward to CanvasImpl (TilemapManager lives there)
 // ---------------------------------------------------------------------------
 
-TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mImplementation->canvasImpl->addTilemap(std::move(tilemap)); }
-void Canvas::removeTilemap(TilemapId tilemapId)                                            { mImplementation->canvasImpl->removeTilemap(tilemapId); }
-Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mImplementation->canvasImpl->tilemap(tilemapId); }
-const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mImplementation->canvasImpl->tilemap(tilemapId); }
-TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mImplementation->canvasImpl->addTilemapExplorer(explorer, *this); }
-void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mImplementation->canvasImpl->removeTilemapExplorer(explorerId, *this); }
-TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mImplementation->canvasImpl->tilemapExplorer(explorerId); }
-const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mImplementation->canvasImpl->tilemapExplorer(explorerId); }
+TilemapId Canvas::addTilemap(Tilemap tilemap)                                              { return mImplementation->canvasImpl.addTilemap(std::move(tilemap)); }
+void Canvas::removeTilemap(TilemapId tilemapId)                                            { mImplementation->canvasImpl.removeTilemap(tilemapId); }
+Tilemap& Canvas::tilemap(TilemapId tilemapId)                                              { return mImplementation->canvasImpl.tilemap(tilemapId); }
+const Tilemap& Canvas::tilemap(TilemapId tilemapId) const                                  { return mImplementation->canvasImpl.tilemap(tilemapId); }
+TilemapExplorerId Canvas::addTilemapExplorer(TilemapExplorer explorer)                     { return mImplementation->canvasImpl.addTilemapExplorer(explorer, *this); }
+void Canvas::removeTilemapExplorer(TilemapExplorerId explorerId)                           { mImplementation->canvasImpl.removeTilemapExplorer(explorerId, *this); }
+TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId)                     { return mImplementation->canvasImpl.tilemapExplorer(explorerId); }
+const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) const         { return mImplementation->canvasImpl.tilemapExplorer(explorerId); }
 
 // ---------------------------------------------------------------------------
 // RTT pass scheduling (the queue lives on CanvasImpl; the ImGui-to-RTT
@@ -166,7 +177,7 @@ const TilemapExplorer& Canvas::tilemapExplorer(TilemapExplorerId explorerId) con
 
 void Canvas::renderTo(RenderTargetId renderTargetId, std::vector<BellotaId> bellotaIds)
 {
-    mImplementation->canvasImpl->renderTo(renderTargetId, std::move(bellotaIds));
+    mImplementation->canvasImpl.renderTo(renderTargetId, std::move(bellotaIds));
 }
 
 void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, ImguiDrawCallback imguiDrawCallback)
@@ -174,7 +185,7 @@ void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, Im
     // Wrap the user's callback with auto-push/pop of fontId. Graceful fallback:
     // if the bake is still pending or the id was removed, the callback runs
     // without an explicit push (the secondary-context default stays in effect).
-    mImplementation->imguiRtt->enqueue(renderTargetId,
+    mImplementation->imguiRtt.enqueue(renderTargetId,
         [this, fontId, cb = std::move(imguiDrawCallback)] {
             if (isImguiFontReady(fontId))
             {
@@ -190,16 +201,16 @@ void Canvas::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, Im
 }
 
 // ---------------------------------------------------------------------------
-// ImGui fonts — forward to mImplementation->imguiRtt->fonts() (or wrap in imgui.h calls)
+// ImGui fonts — forward to mImplementation->imguiRtt.fonts() (or wrap in imgui.h calls)
 // ---------------------------------------------------------------------------
 
-ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mImplementation->imguiRtt->fonts().addSource(ttfBytes, glyphRange); }
-void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)                                          { mImplementation->imguiRtt->fonts().removeSource(sourceId); }
-ImguiFontSourceId Canvas::defaultImguiFontSourceId() const                                              { return mImplementation->imguiRtt->fonts().defaultSourceId(); }
-ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                             { return mImplementation->imguiRtt->fonts().bake(sourceId, sizePx); }
-void Canvas::removeImguiFont(ImguiFontId id)                                                            { mImplementation->imguiRtt->fonts().remove(id); }
-bool Canvas::isImguiFontReady(ImguiFontId id) const                                                     { return mImplementation->imguiRtt->fonts().get(id) != nullptr; }
-ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const                                                   { return mImplementation->imguiRtt->fonts().get(id); }
+ImguiFontSourceId Canvas::addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mImplementation->imguiRtt.fonts().addSource(ttfBytes, glyphRange); }
+void Canvas::removeImguiFontSource(ImguiFontSourceId sourceId)                                          { mImplementation->imguiRtt.fonts().removeSource(sourceId); }
+ImguiFontSourceId Canvas::defaultImguiFontSourceId() const                                              { return mImplementation->imguiRtt.fonts().defaultSourceId(); }
+ImguiFontId Canvas::bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                             { return mImplementation->imguiRtt.fonts().bake(sourceId, sizePx); }
+void Canvas::removeImguiFont(ImguiFontId id)                                                            { mImplementation->imguiRtt.fonts().remove(id); }
+bool Canvas::isImguiFontReady(ImguiFontId id) const                                                     { return mImplementation->imguiRtt.fonts().get(id) != nullptr; }
+ImFont* Canvas::getImguiFontPtr(ImguiFontId id) const                                                   { return mImplementation->imguiRtt.fonts().get(id); }
 
 void Canvas::pushImguiFont(ImguiFontId id)
 {
@@ -216,7 +227,7 @@ void Canvas::popImguiFont()
 
 ImguiFontId Canvas::defaultImguiFontId() const
 {
-    auto idOpt = mImplementation->imguiRtt->fonts().defaultFontId();
+    auto idOpt = mImplementation->imguiRtt.fonts().defaultFontId();
     debugCheck(idOpt.has_value(),
         "Canvas::defaultImguiFontId: no default font registered (Canvas ctor seeds this — should never fire)");
     return *idOpt;
@@ -226,8 +237,8 @@ ImguiFontId Canvas::defaultImguiFontId() const
 // Stats flag
 // ---------------------------------------------------------------------------
 
-bool& Canvas::stats()                                            { return mImplementation->canvasImpl->stats(); }
-const bool& Canvas::stats() const                                { return mImplementation->canvasImpl->stats(); }
+bool& Canvas::stats()                                            { return mImplementation->canvasImpl.stats(); }
+const bool& Canvas::stats() const                                { return mImplementation->canvasImpl.stats(); }
 
 // ---------------------------------------------------------------------------
 // Lifecycle — thread the assets + imguiRtt managers into the frame loop
@@ -237,45 +248,45 @@ void Canvas::run()
 {
     auto update = [](float){};
     Controller controller;
-    mImplementation->canvasImpl->run(*this, *mImplementation->assets, *mImplementation->imguiRtt, update, controller);
+    mImplementation->canvasImpl.run(*this, mImplementation->assets, mImplementation->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update)
 {
     Controller controller;
-    mImplementation->canvasImpl->run(*this, *mImplementation->assets, *mImplementation->imguiRtt, update, controller);
+    mImplementation->canvasImpl.run(*this, mImplementation->assets, mImplementation->imguiRtt, update, controller);
 }
 
 void Canvas::run(std::function<void(float deltaTime)> update, Controller& controller)
 {
-    mImplementation->canvasImpl->run(*this, *mImplementation->assets, *mImplementation->imguiRtt, update, controller);
+    mImplementation->canvasImpl.run(*this, mImplementation->assets, mImplementation->imguiRtt, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update, Controller& controller)
 {
-    mImplementation->canvasImpl->tick(*this, *mImplementation->assets, *mImplementation->imguiRtt, deltaTime, update, controller);
+    mImplementation->canvasImpl.tick(*this, mImplementation->assets, mImplementation->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime, std::function<void(float)> update)
 {
     Controller controller;
-    mImplementation->canvasImpl->tick(*this, *mImplementation->assets, *mImplementation->imguiRtt, deltaTime, update, controller);
+    mImplementation->canvasImpl.tick(*this, mImplementation->assets, mImplementation->imguiRtt, deltaTime, update, controller);
 }
 
 void Canvas::tick(float deltaTime)
 {
     Controller controller;
-    mImplementation->canvasImpl->tick(*this, *mImplementation->assets, *mImplementation->imguiRtt, deltaTime, [](float){}, controller);
+    mImplementation->canvasImpl.tick(*this, mImplementation->assets, mImplementation->imguiRtt, deltaTime, [](float){}, controller);
 }
 
 void Canvas::close()
 {
-    mImplementation->canvasImpl->close();
+    mImplementation->canvasImpl.close();
 }
 
 DirectTexture Canvas::takeScreenshot() const
 {
-    return mImplementation->canvasImpl->takeScreenshot();
+    return mImplementation->canvasImpl.takeScreenshot();
 }
 
 }

--- a/source/canvas_impl.cpp
+++ b/source/canvas_impl.cpp
@@ -5,7 +5,8 @@
 #include "keyboard.h"
 #include "mouse.h"
 #include "controller.h"
-#include "roboto_font.h"
+#include "asset_registry.h"
+#include "imgui_rtt_manager.h"
 #include "backends/render_backend_select.h"
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/matrix_transform_2d.hpp>
@@ -16,6 +17,7 @@
 #include <cmath>
 #include <optional>
 #include <vector>
+#include <span>
 #include <format>
 #include <algorithm>
 #include "profiling.h"
@@ -57,18 +59,12 @@ Canvas::CanvasImpl::CanvasImpl(
     const std::string& title,
     const glm::vec3 clearColor,
     const unsigned int pixelSize,
-    const float imguiFontSize,
     bool headless)
     :
     mScreenSize(screenSize),
     mTitle(title),
     mClearColor(clearColor),
     mPixelSize(pixelSize),
-    mAssets(mBackend),
-    mImguiRtt(mBackend, mAssets.renderTargets(),
-              assets_Roboto_VariableFont_wdth_wght_ttf,
-              assets_Roboto_VariableFont_wdth_wght_ttf_len,
-              imguiFontSize),
     mStats(false),
     mHeadless(headless),
     mGameViewport{0, 0, 0, 0}
@@ -92,22 +88,23 @@ Canvas::CanvasImpl::CanvasImpl(
     mBackend.initialize(mWindow->nativeHandle(), {static_cast<int>(mScreenSize.width), static_cast<int>(mScreenSize.height)});
     mBackend.initImGuiRenderer();
 
-    // Font setup — bake the main HiDPI font (imguiFontSize * contentScale²
-    // for crisp DPI-aware glyphs on the main UI) and seed the secondary-context
-    // default at the unscaled imguiFontSize for diegetic RTT panels.
-    mImguiRtt.fonts().initialize(mWindow->contentScale());
+    // Font setup happens after construction at the Canvas level — once `mAssets`
+    // and `mImguiRtt` exist, Canvas calls `mImguiRtt->fonts().initialize(...)`.
 }
 
 Canvas::CanvasImpl::~CanvasImpl()
 {
-    // Defined here (not =default) to keep the pimpl idiom for struct Window working.
-    // GPU resources must be freed while the GL/Vulkan context is still alive:
-    // - ImGui RTT secondary contexts own per-RTT pipeline/descriptor resources
-    // - mAssets owns texture/mesh/render-target GPU handles
-    // mBackend.shutdown() runs last; mBackend itself is destroyed only after this body.
-    mImguiRtt.releaseAll();
-    mAssets.freeAllGpuResources();
+    // Defined here (not =default) to keep the pimpl idiom for struct Window
+    // working. Canvas's dtor is responsible for draining `mImguiRtt` and
+    // `mAssets` GPU resources BEFORE destroying CanvasImpl — by the time this
+    // body runs they're already torn down, leaving us to shut the backend.
     mBackend.shutdown();
+}
+
+float Canvas::CanvasImpl::contentScale() const
+{
+    debugCheck(mWindow != nullptr, "CanvasImpl::contentScale called before window init");
+    return mWindow->contentScale();
 }
 
 std::size_t Canvas::CanvasImpl::getCurrentMonitor() const
@@ -148,77 +145,6 @@ ScreenSize Canvas::CanvasImpl::windowSize() const
     return mWindow->getWindowSize();
 }
 
-// ---------------------------------------------------------------------------
-// Asset/font remove paths with cross-cutting gates. Plain forwarders are
-// inlined in canvas_impl.h directly onto AssetRegistry / TilemapManager /
-// mImguiRtt.fonts(); only the methods that layer a check or need imgui.h
-// stay here.
-// ---------------------------------------------------------------------------
-
-void Canvas::CanvasImpl::removeBellota(const BellotaId bellotaId)
-{
-    debugCheck(!mTilemapManager.isExplorerManagedBellota(bellotaId.id),
-        "Bellota is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot bellotas directly.");
-    mAssets.removeBellota(bellotaId);
-}
-
-void Canvas::CanvasImpl::removeTexture(const TextureId textureId)
-{
-    debugCheck(!mTilemapManager.isExplorerManagedTexture(textureId.id),
-        "Texture is owned by a TilemapExplorer pool — use canvas.removeTilemapExplorer() instead of removing slot textures directly.");
-    mAssets.removeTexture(textureId);
-}
-
-void Canvas::CanvasImpl::removeRenderTarget(RenderTargetId renderTargetId)
-{
-    // Tear down the secondary ImGui context for this RTT first — its per-context
-    // backend owns GPU resources tied to the RTT's render pass / FBO, which the
-    // registry's removeRenderTarget call is about to free.
-    mImguiRtt.releaseContext(renderTargetId);
-    mAssets.removeRenderTarget(renderTargetId);
-}
-
-void Canvas::CanvasImpl::renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, ImguiDrawCallback imguiDrawCallback)
-{
-    // Wrap the user's callback with auto-push/pop of fontId. Graceful fallback:
-    // if the bake is still pending or the id was removed, the callback runs
-    // without an explicit push (the secondary-context default stays in effect).
-    mImguiRtt.enqueue(renderTargetId,
-        [this, fontId, cb = std::move(imguiDrawCallback)] {
-            if (isImguiFontReady(fontId))
-            {
-                pushImguiFont(fontId);
-                cb();
-                popImguiFont();
-            }
-            else
-            {
-                cb();
-            }
-        });
-}
-
-void Canvas::CanvasImpl::pushImguiFont(ImguiFontId id)
-{
-    ImFont* font = getImguiFontPtr(id);
-    debugCheck(font != nullptr,
-        "Canvas::pushImguiFont: id is not registered or its bake is still pending — guard with isImguiFontReady()");
-    ImGui::PushFont(font);
-}
-
-void Canvas::CanvasImpl::popImguiFont()
-{
-    ImGui::PopFont();
-}
-
-ImguiFontId Canvas::CanvasImpl::defaultImguiFontId() const
-{
-    auto idOpt = mImguiRtt.fonts().defaultFontId();
-    debugCheck(idOpt.has_value(),
-        "Canvas::defaultImguiFontId: no default font registered (CanvasImpl ctor seeds this — should never fire)");
-    return *idOpt;
-}
-
 DirectTexture Canvas::CanvasImpl::takeScreenshot() const
 {
     const glm::ivec2 gameSize{static_cast<int>(mScreenSize.width), static_cast<int>(mScreenSize.height)};
@@ -237,7 +163,6 @@ void Canvas::CanvasImpl::ensureSessionStarted(Controller& controller)
     if (mSessionStarted)
         return;
     mWindow->beginSession(controller);
-    mSortedBellotaPacks.reserve(mAssets.bellotas().size() * 2);
     mSessionStarted = true;
 }
 
@@ -319,7 +244,8 @@ static void drawBellotaPacks(
     }
 }
 
-void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::function<void(float)> update, Controller& controller)
+void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                                     float deltaTimeMS, std::function<void(float)> update, Controller& controller)
 {
     ZoneScopedN("runOneFrame");
 
@@ -333,7 +259,7 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::fun
     // the previous frame's ImGui::Render() and this frame's ImGui::NewFrame().
     // Must run BEFORE mBackend.imguiNewFrame() so ImGui_Impl*_NewFrame()'s
     // lazy font-texture re-upload picks up the rebuilt atlas.
-    mImguiRtt.drainPendingFontOps(mWindow->contentScale());
+    imguiRtt.drainPendingFontOps(mWindow->contentScale());
 
     // Get current framebuffer size and compute letterboxed viewport
     auto [framebufferWidth, framebufferHeight] = mWindow->getFramebufferSize();
@@ -359,32 +285,32 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::fun
     const glm::mat3 worldTransformMat = computeWorldTransformMat(mScreenSize);
 
     if (mAutoTextureGC)
-        mAssets.clearUnusedTextures();
+        assets.clearUnusedTextures();
 
     if (mAutoMeshGC)
-        mAssets.clearUnusedMeshes();
+        assets.clearUnusedMeshes();
 
     {
         ZoneScopedN("TextureUpload");
-        for (auto& [textureIndex, texturePack] : mAssets.textures())
+        for (auto& [textureIndex, texturePack] : assets.textures())
             texturePack.syncToGpu(mBackend);
     }
 
-    for (auto& [renderTargetIndex, renderTargetPack] : mAssets.renderTargets())
+    for (auto& [renderTargetIndex, renderTargetPack] : assets.renderTargets())
     {
         const TextureId proxyTexId = renderTargetPack.renderTarget.mProxyTextureId;
-        renderTargetPack.syncToGpu(mBackend, mAssets.textures().at(proxyTexId.id));
+        renderTargetPack.syncToGpu(mBackend, assets.textures().at(proxyTexId.id));
     }
 
     {
         ZoneScopedN("MeshUpload");
-        for (auto& [meshIndex, meshPack] : mAssets.meshes())
+        for (auto& [meshIndex, meshPack] : assets.meshes())
             meshPack.syncToGpu(mBackend);
     }
 
     {
         ZoneScopedN("DepthSort");
-        sortByDepthOffset(mAssets.bellotas(), mSortedBellotaPacks);
+        sortByDepthOffset(assets.bellotas(), mSortedBellotaPacks);
     }
 
     {
@@ -393,10 +319,10 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::fun
         // before drawing to the main framebuffer.
         for (auto& [renderTargetId, bellotaIds] : mPendingRttPasses)
         {
-            if (not mAssets.renderTargets().contains(renderTargetId.id))
+            if (not assets.renderTargets().contains(renderTargetId.id))
                 continue;
 
-            RenderTargetPack& renderTargetPack = mAssets.renderTargets().at(renderTargetId.id);
+            RenderTargetPack& renderTargetPack = assets.renderTargets().at(renderTargetId.id);
             if (not renderTargetPack.dRenderTargetOpt.has_value())
                 continue;
 
@@ -414,8 +340,8 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::fun
             std::vector<const BellotaPack*> renderTargetSortedPacks;
             for (const BellotaId bellotaId : bellotaIds)
             {
-                if (mAssets.bellotas().contains(bellotaId.id))
-                    renderTargetSortedPacks.push_back(&mAssets.bellotas().at(bellotaId.id));
+                if (assets.bellotas().contains(bellotaId.id))
+                    renderTargetSortedPacks.push_back(&assets.bellotas().at(bellotaId.id));
             }
             std::sort(renderTargetSortedPacks.begin(), renderTargetSortedPacks.end(),
                 [](const BellotaPack* lhs, const BellotaPack* rhs)
@@ -424,7 +350,7 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::fun
                 }
             );
 
-            drawBellotaPacks(renderTargetSortedPacks, mAssets.textures(), mAssets.meshes(), renderTargetWorldTransform, mBackend);
+            drawBellotaPacks(renderTargetSortedPacks, assets.textures(), assets.meshes(), renderTargetWorldTransform, mBackend);
 
             mBackend.endRttPass();
         }
@@ -434,14 +360,14 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::fun
         // render target, rendered with a pipeline compiled against the RTT render
         // pass (Vulkan) or into the RTT FBO (OpenGL). Lazy context creation on
         // first use; destroyed in removeRenderTarget() and the destructor.
-        mImguiRtt.flushPending(deltaTimeMS, ImGui::GetIO().Fonts);
+        imguiRtt.flushPending(deltaTimeMS, ImGui::GetIO().Fonts);
     }
 
     mBackend.beginMainPass(mGameViewport);
 
     {
         ZoneScopedN("MainDraw");
-        drawBellotaPacks(mSortedBellotaPacks, mAssets.textures(), mAssets.meshes(), worldTransformMat, mBackend);
+        drawBellotaPacks(mSortedBellotaPacks, assets.textures(), assets.meshes(), worldTransformMat, mBackend);
     }
 
     if (mStats)
@@ -468,7 +394,8 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, float deltaTimeMS, std::fun
     FrameMark;
 }
 
-void Canvas::CanvasImpl::run(Canvas& canvas, std::function<void(float deltaTime)> update, Controller& controller)
+void Canvas::CanvasImpl::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                             std::function<void(float deltaTime)> update, Controller& controller)
 {
     // Always call beginSession — it resets the window close flag and rebinds
     // input callbacks, which is required after a manifest switch (canvas.close()
@@ -476,7 +403,7 @@ void Canvas::CanvasImpl::run(Canvas& canvas, std::function<void(float deltaTime)
     mWindow->beginSession(controller);
     if (!mSessionStarted)
     {
-        mSortedBellotaPacks.reserve(mAssets.bellotas().size() * 2);
+        mSortedBellotaPacks.reserve(assets.bellotas().size() * 2);
         mSessionStarted = true;
     }
 
@@ -485,14 +412,15 @@ void Canvas::CanvasImpl::run(Canvas& canvas, std::function<void(float deltaTime)
     while (mWindow->isRunning())
     {
         performanceMonitor.update(mWindow->getTime());
-        runOneFrame(canvas, performanceMonitor.getMS(), update, controller);
+        runOneFrame(canvas, assets, imguiRtt, performanceMonitor.getMS(), update, controller);
     }
 }
 
-void Canvas::CanvasImpl::tick(Canvas& canvas, float deltaTimeMS, std::function<void(float)> update, Controller& controller)
+void Canvas::CanvasImpl::tick(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                              float deltaTimeMS, std::function<void(float)> update, Controller& controller)
 {
     ensureSessionStarted(controller);
-    runOneFrame(canvas, deltaTimeMS, update, controller);
+    runOneFrame(canvas, assets, imguiRtt, deltaTimeMS, update, controller);
 }
 
 void Canvas::CanvasImpl::close()

--- a/source/canvas_impl.cpp
+++ b/source/canvas_impl.cpp
@@ -27,7 +27,7 @@ namespace Nothofagus
 
 // Window is the selected backend type. Forward declared in canvas_impl.h;
 // defined here so the backend headers are only included from this translation unit.
-struct Canvas::CanvasImpl::Window : public SelectedWindowBackend
+struct CanvasImpl::Window : public SelectedWindowBackend
 {
     using SelectedWindowBackend::SelectedWindowBackend;
 };
@@ -54,7 +54,7 @@ static ViewportRect computeLetterboxViewport(int framebufferWidth, int framebuff
     return { viewportX, viewportY, viewportWidth, viewportHeight };
 }
 
-Canvas::CanvasImpl::CanvasImpl(
+CanvasImpl::CanvasImpl(
     const ScreenSize& screenSize,
     const std::string& title,
     const glm::vec3 clearColor,
@@ -92,7 +92,7 @@ Canvas::CanvasImpl::CanvasImpl(
     // and `mImguiRtt` exist, Canvas calls `mImguiRtt->fonts().initialize(...)`.
 }
 
-Canvas::CanvasImpl::~CanvasImpl()
+CanvasImpl::~CanvasImpl()
 {
     // Defined here (not =default) to keep the pimpl idiom for struct Window
     // working. Canvas's dtor is responsible for draining `mImguiRtt` and
@@ -101,51 +101,51 @@ Canvas::CanvasImpl::~CanvasImpl()
     mBackend.shutdown();
 }
 
-float Canvas::CanvasImpl::contentScale() const
+float CanvasImpl::contentScale() const
 {
     debugCheck(mWindow != nullptr, "CanvasImpl::contentScale called before window init");
     return mWindow->contentScale();
 }
 
-std::size_t Canvas::CanvasImpl::getCurrentMonitor() const
+std::size_t CanvasImpl::getCurrentMonitor() const
 {
     return mWindow->getCurrentMonitor();
 }
 
-bool Canvas::CanvasImpl::isFullscreen() const
+bool CanvasImpl::isFullscreen() const
 {
     return mWindow->isFullscreen();
 }
 
-void Canvas::CanvasImpl::setFullScreenOnMonitor(std::size_t monitorIndex)
+void CanvasImpl::setFullScreenOnMonitor(std::size_t monitorIndex)
 {
     mLastWindowedAABox = mWindow->getWindowAABox();
     mWindow->setFullscreenOnMonitor(monitorIndex);
 }
 
-AABox Canvas::CanvasImpl::getWindowAABox() const
+AABox CanvasImpl::getWindowAABox() const
 {
     return mWindow->getWindowAABox();
 }
 
-void Canvas::CanvasImpl::setWindowed()
+void CanvasImpl::setWindowed()
 {
     mWindow->setWindowed(mLastWindowedAABox);
 }
 
-void Canvas::CanvasImpl::setWindowTitle(const std::string& title)
+void CanvasImpl::setWindowTitle(const std::string& title)
 {
     mTitle = title;
     mWindow->setWindowTitle(title);
 }
 
-ScreenSize Canvas::CanvasImpl::windowSize() const
+ScreenSize CanvasImpl::windowSize() const
 {
     debugCheck(mWindow != nullptr, "Canvas window has not been initialized");
     return mWindow->getWindowSize();
 }
 
-DirectTexture Canvas::CanvasImpl::takeScreenshot() const
+DirectTexture CanvasImpl::takeScreenshot() const
 {
     const glm::ivec2 gameSize{static_cast<int>(mScreenSize.width), static_cast<int>(mScreenSize.height)};
     ScreenshotPixels pixels = mBackend.takeScreenshot(mGameViewport, gameSize);
@@ -158,7 +158,7 @@ DirectTexture Canvas::CanvasImpl::takeScreenshot() const
 // Frame loop
 // ---------------------------------------------------------------------------
 
-void Canvas::CanvasImpl::ensureSessionStarted(Controller& controller)
+void CanvasImpl::ensureSessionStarted(Controller& controller)
 {
     if (mSessionStarted)
         return;
@@ -244,7 +244,7 @@ static void drawBellotaPacks(
     }
 }
 
-void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+void CanvasImpl::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
                                      float deltaTimeMS, std::function<void(float)> update, Controller& controller)
 {
     ZoneScopedN("runOneFrame");
@@ -394,7 +394,7 @@ void Canvas::CanvasImpl::runOneFrame(Canvas& canvas, AssetRegistry& assets, Imgu
     FrameMark;
 }
 
-void Canvas::CanvasImpl::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+void CanvasImpl::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
                              std::function<void(float deltaTime)> update, Controller& controller)
 {
     // Always call beginSession — it resets the window close flag and rebinds
@@ -416,14 +416,14 @@ void Canvas::CanvasImpl::run(Canvas& canvas, AssetRegistry& assets, ImguiRttMana
     }
 }
 
-void Canvas::CanvasImpl::tick(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+void CanvasImpl::tick(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
                               float deltaTimeMS, std::function<void(float)> update, Controller& controller)
 {
     ensureSessionStarted(controller);
     runOneFrame(canvas, assets, imguiRtt, deltaTimeMS, update, controller);
 }
 
-void Canvas::CanvasImpl::close()
+void CanvasImpl::close()
 {
     mWindow->requestClose();
 }

--- a/source/canvas_impl.cpp
+++ b/source/canvas_impl.cpp
@@ -27,7 +27,7 @@ namespace Nothofagus
 
 // Window is the selected backend type. Forward declared in canvas_impl.h;
 // defined here so the backend headers are only included from this translation unit.
-struct CanvasImpl::Window : public SelectedWindowBackend
+struct FrameRunner::Window : public SelectedWindowBackend
 {
     using SelectedWindowBackend::SelectedWindowBackend;
 };
@@ -54,7 +54,7 @@ static ViewportRect computeLetterboxViewport(int framebufferWidth, int framebuff
     return { viewportX, viewportY, viewportWidth, viewportHeight };
 }
 
-CanvasImpl::CanvasImpl(
+FrameRunner::FrameRunner(
     const ScreenSize& screenSize,
     const std::string& title,
     const glm::vec3 clearColor,
@@ -92,60 +92,60 @@ CanvasImpl::CanvasImpl(
     // and `mImguiRtt` exist, Canvas calls `mImguiRtt->fonts().initialize(...)`.
 }
 
-CanvasImpl::~CanvasImpl()
+FrameRunner::~FrameRunner()
 {
     // Defined here (not =default) to keep the pimpl idiom for struct Window
     // working. Canvas's dtor is responsible for draining `mImguiRtt` and
-    // `mAssets` GPU resources BEFORE destroying CanvasImpl — by the time this
+    // `mAssets` GPU resources BEFORE destroying FrameRunner — by the time this
     // body runs they're already torn down, leaving us to shut the backend.
     mBackend.shutdown();
 }
 
-float CanvasImpl::contentScale() const
+float FrameRunner::contentScale() const
 {
-    debugCheck(mWindow != nullptr, "CanvasImpl::contentScale called before window init");
+    debugCheck(mWindow != nullptr, "FrameRunner::contentScale called before window init");
     return mWindow->contentScale();
 }
 
-std::size_t CanvasImpl::getCurrentMonitor() const
+std::size_t FrameRunner::getCurrentMonitor() const
 {
     return mWindow->getCurrentMonitor();
 }
 
-bool CanvasImpl::isFullscreen() const
+bool FrameRunner::isFullscreen() const
 {
     return mWindow->isFullscreen();
 }
 
-void CanvasImpl::setFullScreenOnMonitor(std::size_t monitorIndex)
+void FrameRunner::setFullScreenOnMonitor(std::size_t monitorIndex)
 {
     mLastWindowedAABox = mWindow->getWindowAABox();
     mWindow->setFullscreenOnMonitor(monitorIndex);
 }
 
-AABox CanvasImpl::getWindowAABox() const
+AABox FrameRunner::getWindowAABox() const
 {
     return mWindow->getWindowAABox();
 }
 
-void CanvasImpl::setWindowed()
+void FrameRunner::setWindowed()
 {
     mWindow->setWindowed(mLastWindowedAABox);
 }
 
-void CanvasImpl::setWindowTitle(const std::string& title)
+void FrameRunner::setWindowTitle(const std::string& title)
 {
     mTitle = title;
     mWindow->setWindowTitle(title);
 }
 
-ScreenSize CanvasImpl::windowSize() const
+ScreenSize FrameRunner::windowSize() const
 {
     debugCheck(mWindow != nullptr, "Canvas window has not been initialized");
     return mWindow->getWindowSize();
 }
 
-DirectTexture CanvasImpl::takeScreenshot() const
+DirectTexture FrameRunner::takeScreenshot() const
 {
     const glm::ivec2 gameSize{static_cast<int>(mScreenSize.width), static_cast<int>(mScreenSize.height)};
     ScreenshotPixels pixels = mBackend.takeScreenshot(mGameViewport, gameSize);
@@ -158,7 +158,7 @@ DirectTexture CanvasImpl::takeScreenshot() const
 // Frame loop
 // ---------------------------------------------------------------------------
 
-void CanvasImpl::ensureSessionStarted(Controller& controller)
+void FrameRunner::ensureSessionStarted(Controller& controller)
 {
     if (mSessionStarted)
         return;
@@ -244,7 +244,7 @@ static void drawBellotaPacks(
     }
 }
 
-void CanvasImpl::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
                                      float deltaTimeMS, std::function<void(float)> update, Controller& controller)
 {
     ZoneScopedN("runOneFrame");
@@ -394,7 +394,7 @@ void CanvasImpl::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMana
     FrameMark;
 }
 
-void CanvasImpl::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+void FrameRunner::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
                              std::function<void(float deltaTime)> update, Controller& controller)
 {
     // Always call beginSession — it resets the window close flag and rebinds
@@ -416,14 +416,14 @@ void CanvasImpl::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& img
     }
 }
 
-void CanvasImpl::tick(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+void FrameRunner::tick(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
                               float deltaTimeMS, std::function<void(float)> update, Controller& controller)
 {
     ensureSessionStarted(controller);
     runOneFrame(canvas, assets, imguiRtt, deltaTimeMS, update, controller);
 }
 
-void CanvasImpl::close()
+void FrameRunner::close()
 {
     mWindow->requestClose();
 }

--- a/source/canvas_impl.h
+++ b/source/canvas_impl.h
@@ -14,7 +14,7 @@
 namespace Nothofagus
 {
 
-// Forward decls — CanvasImpl only takes these by reference (in run/tick), so
+// Forward decls — FrameRunner only takes these by reference (in run/tick), so
 // the full headers don't need to be visible here. canvas_impl.h is an
 // internal header (never reached by the public canvas.h), so these names
 // at namespace scope stay out of the public-API surface.
@@ -22,22 +22,22 @@ class AssetRegistry;
 class ImguiRttManager;
 
 /**
- * @class CanvasImpl
+ * @class FrameRunner
  * @brief Internal owner of the GPU backend, window/input backend, and the
  * per-frame render loop. Asset CRUD (textures/meshes/bellotas/render targets)
  * and the canvas-wide ImGui font / RTT-context manager live on `Canvas`
- * itself; CanvasImpl exposes the GPU backend and the small predicates the
+ * itself; FrameRunner exposes the GPU backend and the small predicates the
  * cross-cutting gates need.
  *
- * Construction order in `Canvas`'s ctor is `mCanvasImpl` first (this builds
- * `mBackend`), then `mAssets(mCanvasImpl->backend())`, then
- * `mImguiRtt(mCanvasImpl->backend(), mAssets->renderTargets(), …)`.
+ * Construction order in `Canvas`'s ctor is `mFrameRunner` first (this builds
+ * `mBackend`), then `mAssets(mFrameRunner->backend())`, then
+ * `mImguiRtt(mFrameRunner->backend(), mAssets->renderTargets(), …)`.
  */
-class CanvasImpl
+class FrameRunner
 {
 public:
 
-    CanvasImpl(
+    FrameRunner(
         const ScreenSize& screenSize,
         const std::string& title,
         const glm::vec3 clearColor,
@@ -47,9 +47,9 @@ public:
 
     /// Destructor to clean up resources and terminate the window backend.
     /// Caller (Canvas) must drain `mImguiRtt` and `mAssets` GPU resources
-    /// BEFORE destroying CanvasImpl, because `~CanvasImpl` shuts the backend
+    /// BEFORE destroying FrameRunner, because `~FrameRunner` shuts the backend
     /// down.
-    ~CanvasImpl();
+    ~FrameRunner();
 
     // ----- Backend access (internal, never reaches the public canvas.h surface) -----
     ActiveBackend&       backend()       noexcept { return mBackend; }
@@ -81,7 +81,7 @@ public:
     void setAutoRemoveUnusedTextures(bool enabled)                                          { mAutoTextureGC = enabled; }
     void setAutoRemoveUnusedMeshes(bool enabled)                                            { mAutoMeshGC = enabled; }
 
-    // ----- Tilemaps (TilemapManager stays with CanvasImpl) -----
+    // ----- Tilemaps (TilemapManager stays with FrameRunner) -----
     TilemapId addTilemap(Tilemap tilemap)                                                   { return mTilemapManager.addTilemap(std::move(tilemap)); }
     void removeTilemap(TilemapId tilemapId)                                                 { mTilemapManager.removeTilemap(tilemapId); }
     Tilemap& tilemap(TilemapId tilemapId)                                                   { return mTilemapManager.tilemap(tilemapId); }

--- a/source/canvas_impl.h
+++ b/source/canvas_impl.h
@@ -4,34 +4,34 @@
 #include "tilemap.h"
 #include "tilemap_explorer.h"
 #include "tilemap_manager.h"
-#include "asset_registry.h"
-#include "imgui_rtt_manager.h"
-#include "imgui_font_source_id.h"
+#include "bellota_container.h"   // for BellotaPack in mSortedBellotaPacks
 #include "aa_box.h"
 #include "backends/render_backend_select.h"
 #include <vector>
 #include <utility>
-#include <span>
 #include <cstddef>
-
-struct ImFont;
 
 namespace Nothofagus
 {
 
+// Forward decls — CanvasImpl only takes these by reference (in run/tick), so
+// the full headers don't need to be visible here. canvas_impl.h is an
+// internal header (never reached by the public canvas.h), so these names
+// at namespace scope stay out of the public-API surface.
+class AssetRegistry;
+class ImguiRttManager;
+
 /**
  * @class Canvas::CanvasImpl
- * @brief Implementation of the Canvas class, responsible for managing the actual window, textures, Bellotas, and rendering.
+ * @brief Internal owner of the GPU backend, window/input backend, and the
+ * per-frame render loop. Asset CRUD (textures/meshes/bellotas/render targets)
+ * and the canvas-wide ImGui font / RTT-context manager live on `Canvas`
+ * itself; CanvasImpl exposes the GPU backend and the small predicates the
+ * cross-cutting gates need.
  *
- * Encapsulates the low-level details of the Canvas: window/input backend,
- * GPU rendering backend, asset containers, the frame loop, and screenshot
- * capture. Most asset/state accessors are inline forwarders onto the
- * `mAssets` (AssetRegistry), `mTilemapManager`, and `mImguiRtt.fonts()`
- * members. The out-of-line definitions in canvas_impl.cpp are the ones
- * that (a) depend on the pimpl-hidden `Window` type, (b) need imgui.h or
- * carry non-trivial multi-statement logic, or (c) layer a cross-cutting
- * gate (tilemap-pool ownership, ImGui RTT teardown) on top of an asset
- * forwarder.
+ * Construction order in `Canvas`'s ctor is `mCanvasImpl` first (this builds
+ * `mBackend`), then `mAssets(mCanvasImpl->backend())`, then
+ * `mImguiRtt(mCanvasImpl->backend(), mAssets->renderTargets(), …)`.
  */
 class Canvas::CanvasImpl
 {
@@ -42,12 +42,24 @@ public:
         const std::string& title,
         const glm::vec3 clearColor,
         const unsigned int pixelSize,
-        const float imguiFontSize,
         bool headless = false
     );
 
-    /// Destructor to clean up resources and terminate the window backend
+    /// Destructor to clean up resources and terminate the window backend.
+    /// Caller (Canvas) must drain `mImguiRtt` and `mAssets` GPU resources
+    /// BEFORE destroying CanvasImpl, because `~CanvasImpl` shuts the backend
+    /// down.
     ~CanvasImpl();
+
+    // ----- Backend access (internal, never reaches the public canvas.h surface) -----
+    ActiveBackend&       backend()       noexcept { return mBackend; }
+    const ActiveBackend& backend() const noexcept { return mBackend; }
+    /// Window content scale (DPI factor) — only valid after construction.
+    float                contentScale() const;
+
+    // ----- Cross-cutting predicates used by Canvas's remove-gates -----
+    bool isExplorerManagedBellota(std::size_t bellotaId) const { return mTilemapManager.isExplorerManagedBellota(bellotaId); }
+    bool isExplorerManagedTexture(std::size_t textureId) const { return mTilemapManager.isExplorerManagedTexture(textureId); }
 
     // ----- Window / display (depend on pimpl-hidden Window) -----
     std::size_t getCurrentMonitor() const;
@@ -69,41 +81,7 @@ public:
     void setAutoRemoveUnusedTextures(bool enabled)                                          { mAutoTextureGC = enabled; }
     void setAutoRemoveUnusedMeshes(bool enabled)                                            { mAutoMeshGC = enabled; }
 
-    // ----- Bellotas -----
-    BellotaId addBellota(const Bellota& bellota)                                            { return mAssets.addBellota(bellota); }
-    void removeBellota(const BellotaId bellotaId);     // tilemap-pool ownership gate — defined in cpp
-    Bellota& bellota(BellotaId bellotaId)                                                   { return mAssets.bellota(bellotaId); }
-    const Bellota& bellota(BellotaId bellotaId) const                                       { return mAssets.bellota(bellotaId); }
-    void setTint(const BellotaId bellotaId, const Tint& tint)                               { mAssets.setTint(bellotaId, tint); }
-    void removeTint(const BellotaId bellotaId)                                              { mAssets.removeTint(bellotaId); }
-
-    // ----- Textures -----
-    TextureId addTexture(const Texture& texture)                                            { return mAssets.addTexture(texture); }
-    void removeTexture(const TextureId textureId);     // tilemap-pool ownership gate — defined in cpp
-    void setTexture(const BellotaId bellotaId, const TextureId textureId)                   { mAssets.setTexture(bellotaId, textureId); }
-    void markTextureAsDirty(const TextureId textureId)                                      { mAssets.markTextureAsDirty(textureId); }
-    void setTextureMinFilter(const TextureId textureId, TextureSampleMode mode)             { mAssets.setTextureMinFilter(textureId, mode); }
-    void setTextureMagFilter(const TextureId textureId, TextureSampleMode mode)             { mAssets.setTextureMagFilter(textureId, mode); }
-    Texture& texture(TextureId textureId)                                                   { return mAssets.texture(textureId); }
-    const Texture& texture(TextureId textureId) const                                       { return mAssets.texture(textureId); }
-    Texture& textureArray(TextureId textureId);                                             // legacy declaration — no definition; calling it is a link error
-    const Texture& textureArray(TextureId textureId) const;                                 // legacy declaration — no definition; calling it is a link error
-
-    // ----- Meshes -----
-    MeshId addMesh(const Mesh& mesh)                                                        { return mAssets.addMesh(mesh); }
-    MeshId addMesh(Mesh&& mesh)                                                             { return mAssets.addMesh(std::move(mesh)); }
-    void removeMesh(MeshId meshId)                                                          { mAssets.removeMesh(meshId); }
-    void setMesh(const BellotaId bellotaId, const MeshId meshId)                            { mAssets.setMesh(bellotaId, meshId); }
-    const Mesh& mesh(MeshId meshId) const                                                   { return mAssets.mesh(meshId); }
-    const Mesh& mesh(BellotaId bellotaId) const                                             { return mAssets.mesh(bellotaId); }
-
-    // ----- Render targets -----
-    RenderTargetId addRenderTarget(ScreenSize size)                                         { return mAssets.addRenderTarget(size); }
-    void removeRenderTarget(RenderTargetId renderTargetId);    // ImGui RTT context teardown first — defined in cpp
-    TextureId renderTargetTexture(RenderTargetId renderTargetId) const                      { return mAssets.renderTargetTexture(renderTargetId); }
-    void setRenderTargetClearColor(RenderTargetId renderTargetId, glm::vec4 clearColor)     { mAssets.setRenderTargetClearColor(renderTargetId, clearColor); }
-
-    // ----- Tilemaps -----
+    // ----- Tilemaps (TilemapManager stays with CanvasImpl) -----
     TilemapId addTilemap(Tilemap tilemap)                                                   { return mTilemapManager.addTilemap(std::move(tilemap)); }
     void removeTilemap(TilemapId tilemapId)                                                 { mTilemapManager.removeTilemap(tilemapId); }
     Tilemap& tilemap(TilemapId tilemapId)                                                   { return mTilemapManager.tilemap(tilemapId); }
@@ -113,36 +91,26 @@ public:
     TilemapExplorer& tilemapExplorer(TilemapExplorerId explorerId)                          { return mTilemapManager.tilemapExplorer(explorerId); }
     const TilemapExplorer& tilemapExplorer(TilemapExplorerId explorerId) const              { return mTilemapManager.tilemapExplorer(explorerId); }
 
-    // ----- RTT pass scheduling -----
+    // ----- RTT pass scheduling (the queue lives here; consumed in runOneFrame) -----
     void renderTo(RenderTargetId renderTargetId, std::vector<BellotaId> bellotaIds)         { mPendingRttPasses.emplace_back(renderTargetId, std::move(bellotaIds)); }
-    void renderImguiTo(RenderTargetId renderTargetId, ImguiFontId fontId, ImguiDrawCallback imguiDrawCallback);
-
-    // ----- ImGui fonts -----
-    ImguiFontSourceId addImguiFontSource(std::span<const std::byte> ttfBytes, GlyphRange glyphRange) { return mImguiRtt.fonts().addSource(ttfBytes, glyphRange); }
-    void removeImguiFontSource(ImguiFontSourceId sourceId)                                           { mImguiRtt.fonts().removeSource(sourceId); }
-    ImguiFontSourceId defaultImguiFontSourceId() const                                               { return mImguiRtt.fonts().defaultSourceId(); }
-    ImguiFontId bakeImguiFont(ImguiFontSourceId sourceId, float sizePx)                              { return mImguiRtt.fonts().bake(sourceId, sizePx); }
-    void removeImguiFont(ImguiFontId id)                                                             { mImguiRtt.fonts().remove(id); }
-    bool isImguiFontReady(ImguiFontId id) const                                                      { return mImguiRtt.fonts().get(id) != nullptr; }
-    ImFont* getImguiFontPtr(ImguiFontId id) const                                                    { return mImguiRtt.fonts().get(id); }
-    void pushImguiFont(ImguiFontId id);            // needs imgui.h + debugCheck on optional — defined in cpp
-    void popImguiFont();                            // needs imgui.h — defined in cpp
-    ImguiFontId defaultImguiFontId() const;         // debugCheck on optional — defined in cpp
 
     // ----- Lifecycle -----
-    /// Runs the main loop of the canvas with a custom update function.
-    /// @param canvas Reference to the owning Canvas, threaded through to TilemapManager.
-    void run(Canvas& canvas, std::function<void(float deltaTime)> update, Controller& controller);
+    /// Runs the main loop. Threads through the Canvas-owned asset registry and
+    /// ImGui RTT manager so runOneFrame doesn't need direct member access.
+    void run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+             std::function<void(float deltaTime)> update, Controller& controller);
 
     /// Execute a single frame with a caller-supplied delta time (in milliseconds).
-    void tick(Canvas& canvas, float deltaTimeMS, std::function<void(float)> update, Controller& controller);
+    void tick(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+              float deltaTimeMS, std::function<void(float)> update, Controller& controller);
 
     /// Captures the last rendered frame visible to the user as a DirectTexture (RGBA).
     DirectTexture takeScreenshot() const;
 
 private:
     void ensureSessionStarted(Controller& controller);
-    void runOneFrame(Canvas& canvas, float deltaTimeMS, std::function<void(float)> update, Controller& controller);
+    void runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                     float deltaTimeMS, std::function<void(float)> update, Controller& controller);
 
     ScreenSize mScreenSize; ///< The screen size of the canvas.
     std::string mTitle; ///< The title of the canvas window.
@@ -151,23 +119,10 @@ private:
 
     ActiveBackend mBackend; ///< GPU rendering backend (compile-time selected).
 
-    /// Owns the four CPU-side asset containers (textures, bellotas, meshes,
-    /// render targets) and the two usage monitors. Holds a reference to
-    /// mBackend so per-asset removes can free GPU resources eagerly;
-    /// bulk teardown goes through mAssets.freeAllGpuResources() in the dtor.
-    /// Declared after mBackend so the reference is bound to a live backend.
-    AssetRegistry mAssets;
-
     TilemapManager mTilemapManager; ///< Huge-tilemap storage + per-frame explorer pool logic.
 
     /// RTT passes queued by renderTo() during the update callback, executed before the main render.
     std::vector<std::pair<RenderTargetId, std::vector<BellotaId>>> mPendingRttPasses;
-
-    /// Owns per-RTT secondary ImGuiContexts + the per-frame RTT pass queue,
-    /// AND the canvas-wide ImGui font manager (main HiDPI font + RTT default
-    /// + user-baked sizes; deferred bake/remove queue + atlas rebuild).
-    /// Declared after mBackend / mAssets so initialization order is well-defined.
-    ImguiRttManager mImguiRtt;
 
     bool mStats; ///< Flag to indicate whether stats should be displayed.
     bool mHeadless{false}; ///< When true, the window is hidden (no visible UI).

--- a/source/canvas_impl.h
+++ b/source/canvas_impl.h
@@ -22,7 +22,7 @@ class AssetRegistry;
 class ImguiRttManager;
 
 /**
- * @class Canvas::CanvasImpl
+ * @class CanvasImpl
  * @brief Internal owner of the GPU backend, window/input backend, and the
  * per-frame render loop. Asset CRUD (textures/meshes/bellotas/render targets)
  * and the canvas-wide ImGui font / RTT-context manager live on `Canvas`
@@ -33,7 +33,7 @@ class ImguiRttManager;
  * `mBackend`), then `mAssets(mCanvasImpl->backend())`, then
  * `mImguiRtt(mCanvasImpl->backend(), mAssets->renderTargets(), …)`.
  */
-class Canvas::CanvasImpl
+class CanvasImpl
 {
 public:
 

--- a/source/imgui_font_manager.h
+++ b/source/imgui_font_manager.h
@@ -47,7 +47,7 @@ public:
     /// to the shared atlas at `imguiFontSize * contentScale * contentScale`,
     /// then bakes a font at the unscaled `imguiFontSize` from the default
     /// source and registers it as the secondary-context default. Call from
-    /// CanvasImpl's constructor body after backend initImGuiRenderer.
+    /// FrameRunner's constructor body after backend initImGuiRenderer.
     void initialize(float contentScale);
 
     /// True if there are queued ops awaiting drain.

--- a/source/imgui_rtt_manager.h
+++ b/source/imgui_rtt_manager.h
@@ -70,7 +70,7 @@ public:
     /// Drain the font manager's queued ops + rebuild the atlas + refresh
     /// secondary contexts + drop the GPU font texture so the next NewFrame
     /// re-uploads it. No-op when the font manager has no pending ops.
-    /// Called by CanvasImpl::runOneFrame at the top of each frame.
+    /// Called by FrameRunner::runOneFrame at the top of each frame.
     void drainPendingFontOps(float contentScale);
 
     /// Access to the canvas-wide ImGui font manager (main HiDPI font + RTT

--- a/source/imgui_rtt_manager.h
+++ b/source/imgui_rtt_manager.h
@@ -70,7 +70,7 @@ public:
     /// Drain the font manager's queued ops + rebuild the atlas + refresh
     /// secondary contexts + drop the GPU font texture so the next NewFrame
     /// re-uploads it. No-op when the font manager has no pending ops.
-    /// Called by Canvas::CanvasImpl::runOneFrame at the top of each frame.
+    /// Called by CanvasImpl::runOneFrame at the top of each frame.
     void drainPendingFontOps(float contentScale);
 
     /// Access to the canvas-wide ImGui font manager (main HiDPI font + RTT

--- a/source/tilemap_manager.h
+++ b/source/tilemap_manager.h
@@ -43,7 +43,7 @@ public:
     const TilemapExplorer& tilemapExplorer(TilemapExplorerId id) const;
 
     // ── Per-frame pre-pass (needs canvas access to mutate slot bellotas + textures) ─
-    /// Runs in `Canvas::CanvasImpl::runOneFrame` between the user update and
+    /// Runs in `CanvasImpl::runOneFrame` between the user update and
     /// the texture upload pass. For each explorer, assigns visible world chunks
     /// to pool slots, memcpys chunk data into the slot's IndirectTexture
     /// via `setMapBulk`, and repositions/un-hides the slot bellota.

--- a/source/tilemap_manager.h
+++ b/source/tilemap_manager.h
@@ -43,7 +43,7 @@ public:
     const TilemapExplorer& tilemapExplorer(TilemapExplorerId id) const;
 
     // ── Per-frame pre-pass (needs canvas access to mutate slot bellotas + textures) ─
-    /// Runs in `CanvasImpl::runOneFrame` between the user update and
+    /// Runs in `FrameRunner::runOneFrame` between the user update and
     /// the texture upload pass. For each explorer, assigns visible world chunks
     /// to pool slots, memcpys chunk data into the slot's IndirectTexture
     /// via `setMapBulk`, and repositions/un-hides the slot bellota.


### PR DESCRIPTION
Continues the CanvasImpl decomposition. Canvas was still wearing a god-object shape after AssetRegistry / freeGpuResources / syncToGpu landed: the asset registry and the ImGui RTT manager lived inside CanvasImpl, the frame loop reached for them directly, and the whole thing was hidden behind a single pimpl. This PR splits responsibility into three peer classes, hosts them on Canvas itself, and rewires the frame loop to take them as parameters.

User-facing Canvas API is unchanged — every public method has the same signature and observable behavior. All examples and tests compile and run without modification.

## End-state layering

- **`FrameRunner`** (formerly `Canvas::CanvasImpl`, promoted from nested → namespace-scope class). Owns the GPU backend (`ActiveBackend`), the window (`Window`), `TilemapManager`, the per-frame RTT pass queue, and `runOneFrame` / `run` / `tick`. Exposes `backend()`, `contentScale()`, and two predicates (`isExplorerManagedBellota/Texture`) needed by Canvas's cross-cutting gates.
- **`AssetRegistry`** — CPU-side asset CRUD (textures, bellotas, meshes, render targets) + the two ResourceUsageMonitor` instances. Unchanged from prior PRs; just relocated.
- **`ImguiRttManager`** — per-RTT secondary ImGui contexts + canvas-wide font manager. Also relocated.
- **`Canvas`** — public API. Forwards asset/font calls direct to mAssets / mImguiRtt; hosts the three cross-cutting remove-gates (tilemap-pool ownership checks on `removeBellota` / `removeTexture`; ImGui RTT context teardown on `removeRenderTarget`).

## Wiring (canvas.cpp)

A single nested `struct Canvas::Implementation` holds all three by value, in
declaration order matching the staged construction:

```cpp
struct Canvas::Implementation
{
    Implementation(/* args */)
        : frameRunner(screenSize, title, clearColor, pixelSize, headless),
          assets(frameRunner.backend()),
          imguiRtt(frameRunner.backend(), assets.renderTargets(),
                   roboto_bytes, roboto_len, imguiFontSize)
    {
        imguiRtt.fonts().initialize(frameRunner.contentScale());
    }

    FrameRunner      frameRunner;
    AssetRegistry    assets;
    ImguiRttManager  imguiRtt;
};
```

Canvas holds `std::unique_ptr<Implementation> mImplPtr`. One heap allocation total (vs four in an earlier iteration of this branch that used three separate unique_ptrs). Reverse-destruction matches the GPU teardown order: imguiRtt → assets → frameRunner (whose dtor calls `mBackend.shutdown()`).

## Public-API surface stays clean
The whole point of holding everything in `Canvas::Implementation` is to keep internal type names out of the Nothofagus namespace as seen through canvas.h. After this PR, canvas.h forward-declares exactly one nested type — struct `Canvas::Implementation;` — and includes zero backend headers. `Nothofagus::FrameRunner`, `Nothofagus::AssetRegistry`, and `Nothofagus::ImguiRttManager` are reachable only via the internal source/canvas_impl.h / source/asset_registry.h / source/imgui_rtt_manager.h, which user code never includes. 

https://github.com/dantros/nothofagus/issues/45