### PR TITLE
Adding missing SDL_WINDOW_HIGH_PIXEL_DENSITY to SDL backend

### DIFF
--- a/source/backends/sdl3_backend.cpp
+++ b/source/backends/sdl3_backend.cpp
@@ -23,13 +23,13 @@ Sdl3Backend::Sdl3Backend(const std::string& title, int width, int height, bool v
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD);
 
 #if defined(NOTHOFAGUS_BACKEND_VULKAN)
-    SDL_WindowFlags windowFlags = SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE;
+    SDL_WindowFlags windowFlags = SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #else
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
-    SDL_WindowFlags windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
+    SDL_WindowFlags windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #endif
     if (!visible)
         windowFlags |= SDL_WINDOW_HIDDEN;


### PR DESCRIPTION
OS scaling was not properly identified on Linux Wayland