### PR TITLE
Make the frame loop snapshot-driven (sim/render seam, single-threaded)

### DIFF
--- a/source/asset_registry.cpp
+++ b/source/asset_registry.cpp
@@ -180,6 +180,30 @@ void AssetRegistry::clearUnusedTextures()
     mTextureUsageMonitor.clearUnusedIds();
 }
 
+std::vector<TextureId> AssetRegistry::collectUnusedTextures()
+{
+    std::vector<TextureId> collected;
+    const std::unordered_set<TextureId> unusedTextureIdsCopy = mTextureUsageMonitor.getUnusedIds();
+    for (TextureId textureId : unusedTextureIdsCopy)
+    {
+        // Proxy entries are owned by their RenderTargetPack — skip auto-cleanup.
+        if (mTextures.at(textureId.id).isProxy())
+            continue;
+        const bool removed = mTextureUsageMonitor.removeUnused(textureId);
+        debugCheck(removed, "collectUnusedTextures: texture vanished from the unused set unexpectedly");
+        collected.push_back(textureId);
+    }
+    // Clears whatever remains (the skipped proxies), matching clearUnusedTextures().
+    mTextureUsageMonitor.clearUnusedIds();
+    return collected;
+}
+
+void AssetRegistry::freeRetiredTexture(TextureId textureId)
+{
+    mTextures.at(textureId.id).freeGpuResources(mBackend);
+    mTextures.remove(textureId.id);
+}
+
 // ---------------------------------------------------------------------------
 // Meshes
 // ---------------------------------------------------------------------------
@@ -276,6 +300,25 @@ void AssetRegistry::clearUnusedMeshes()
         mMeshes.at(meshId.id).freeGpuResources(mBackend);
         mMeshes.remove(meshId.id);
     }
+}
+
+std::vector<MeshId> AssetRegistry::collectUnusedMeshes()
+{
+    std::vector<MeshId> collected;
+    const std::unordered_set<MeshId> unusedMeshIdsCopy = mMeshUsageMonitor.getUnusedIds();
+    for (MeshId meshId : unusedMeshIdsCopy)
+    {
+        const bool removed = mMeshUsageMonitor.removeUnused(meshId);
+        debugCheck(removed, "collectUnusedMeshes: mesh vanished from the unused set unexpectedly");
+        collected.push_back(meshId);
+    }
+    return collected;
+}
+
+void AssetRegistry::freeRetiredMesh(MeshId meshId)
+{
+    mMeshes.at(meshId.id).freeGpuResources(mBackend);
+    mMeshes.remove(meshId.id);
 }
 
 // ---------------------------------------------------------------------------

--- a/source/asset_registry.h
+++ b/source/asset_registry.h
@@ -14,6 +14,7 @@
 #include "backends/render_backend_select.h"
 
 #include <glm/glm.hpp>
+#include <vector>
 
 namespace Nothofagus
 {
@@ -59,6 +60,20 @@ public:
     const Texture& texture(TextureId textureId) const;
     void clearUnusedTextures();
 
+    /// Detect-only counterpart to clearUnusedTextures(): returns the non-proxy
+    /// textures currently unreferenced by any bellota and removes them from the
+    /// usage monitor, WITHOUT freeing GPU resources. The caller (the deferred-
+    /// free path) frees each later via freeRetiredTexture() once no in-flight
+    /// render snapshot still references it. Proxy textures are skipped (they are
+    /// RT-owned) and the unused set is cleared afterwards — identical monitor
+    /// side effects to clearUnusedTextures(), minus the immediate free.
+    std::vector<TextureId> collectUnusedTextures();
+
+    /// Free GPU resources for a texture returned by collectUnusedTextures() and
+    /// erase it from the container. Does not touch the usage monitor — that was
+    /// already done by collectUnusedTextures().
+    void freeRetiredTexture(TextureId textureId);
+
     // ---------- Meshes ----------
     MeshId addMesh(const Mesh& mesh);
     MeshId addMesh(Mesh&& mesh);
@@ -67,6 +82,17 @@ public:
     const Mesh& mesh(MeshId meshId) const;
     const Mesh& mesh(BellotaId bellotaId) const;
     void clearUnusedMeshes();
+
+    /// Detect-only counterpart to clearUnusedMeshes(): returns the meshes
+    /// currently unreferenced by any bellota and removes them from the usage
+    /// monitor, WITHOUT freeing GPU resources. Auto-quads and user meshes are
+    /// treated alike (same eligibility as clearUnusedMeshes). Free each later
+    /// via freeRetiredMesh().
+    std::vector<MeshId> collectUnusedMeshes();
+
+    /// Free GPU resources for a mesh returned by collectUnusedMeshes() and erase
+    /// it from the container. Does not touch the usage monitor.
+    void freeRetiredMesh(MeshId meshId);
 
     // ---------- Render targets ----------
     RenderTargetId addRenderTarget(ScreenSize size);

--- a/source/frame_runner.cpp
+++ b/source/frame_runner.cpp
@@ -204,10 +204,10 @@ static glm::mat3 computeWorldTransformMat(const ScreenSize& screenSize)
     return glm::scale(worldTransformMat, worldScale);
 }
 
-static SpriteDrawParams makeSpriteDrawParams(const BellotaPack& pack, const glm::mat3& worldTransform)
+static DrawItem makeDrawItem(const BellotaPack& pack)
 {
     const Bellota& bellota = pack.bellota;
-    const glm::mat3 totalTransform = worldTransform * bellota.transform().toMat3();
+    debugCheck(bellota.meshId().has_value(), "BellotaPack is missing a MeshId — invariant broken");
     glm::vec3 tintColor{1.0f, 1.0f, 1.0f};
     float tintIntensity = 0.0f;
     if (pack.tintOpt.has_value())
@@ -215,55 +215,62 @@ static SpriteDrawParams makeSpriteDrawParams(const BellotaPack& pack, const glm:
         tintColor     = pack.tintOpt.value().color;
         tintIntensity = pack.tintOpt.value().intensity;
     }
-    return SpriteDrawParams{
-        totalTransform,
+    return DrawItem{
+        bellota.transform().toMat3(),
+        bellota.texture(),
+        bellota.meshId().value(),
         static_cast<int>(bellota.currentLayer()),
         tintColor,
         tintIntensity,
-        bellota.opacity()
+        bellota.opacity(),
+        bellota.depthOffset()
     };
 }
 
-static void sortByDepthOffset(const BellotaContainer& bellotas, std::vector<const BellotaPack*>& sortedBellotas)
+// Project the visible bellotas into a depth-sorted POD draw list. Iterating the
+// same container in the same order as before and sorting on the same key keeps
+// the resulting draw order identical to the previous pointer-based path.
+static void buildMainDraws(const BellotaContainer& bellotas, std::vector<DrawItem>& out)
 {
-    // Per spec, clear does not change the underlaying memory allocation (capacity)
-    sortedBellotas.clear();
+    out.clear(); // keeps capacity per spec
 
     for (const auto& [bellotaIndex, bellotaPack] : bellotas)
     {
-        if (not bellotaPack.bellota.visible()) continue;   // hidden ones never enter the sort
-        sortedBellotas.push_back(&bellotaPack);
+        if (not bellotaPack.bellota.visible()) continue; // hidden ones never enter the sort
+        out.push_back(makeDrawItem(bellotaPack));
     }
 
-    std::sort(sortedBellotas.begin(), sortedBellotas.end(),
-        [](const BellotaPack* lhs, const BellotaPack* rhs)
+    std::sort(out.begin(), out.end(),
+        [](const DrawItem& lhs, const DrawItem& rhs)
         {
-            debugCheck(lhs != nullptr and rhs != nullptr, "invalid pointers");
-            const auto lhsDepthOffset = lhs->bellota.depthOffset();
-            const auto rhsDepthOffset = rhs->bellota.depthOffset();
-            return lhsDepthOffset < rhsDepthOffset;
+            return lhs.depthOffset < rhs.depthOffset;
         }
     );
 }
 
-static void drawBellotaPacks(
-    std::span<const BellotaPack* const> sortedBellotaPacks,
+// Render a POD draw list. Resolves each item's texture/mesh id to its GPU handle
+// at draw time — the snapshot only carries ids because handles do not exist yet
+// at commit time.
+static void drawItems(
+    std::span<const DrawItem> items,
     const TextureContainer& textures,
     const MeshContainer& meshes,
     const glm::mat3& worldTransform,
     ActiveBackend& backend)
 {
-    for (const BellotaPack* packPtr : sortedBellotaPacks)
+    for (const DrawItem& item : items)
     {
-        // Callers (sortByDepthOffset / the RTT pre-pass gather) pre-filter hidden
-        // bellotas, so this list is visible-only by invariant — no visible() check here.
-        debugCheck(packPtr->bellota.visible());
-        if (!packPtr->bellota.meshId().has_value()) continue;
-        const MeshPack& meshPack = meshes.at(packPtr->bellota.meshId().value().id);
+        const MeshPack& meshPack = meshes.at(item.mesh.id);
         if (!meshPack.dmeshOpt.has_value()) continue;
-        const TexturePack& texturePack = textures.at(packPtr->bellota.texture().id);
+        const TexturePack& texturePack = textures.at(item.texture.id);
         if (!texturePack.dtextureOpt.has_value()) continue;
-        SpriteDrawParams drawParams = makeSpriteDrawParams(*packPtr, worldTransform);
+        SpriteDrawParams drawParams{
+            worldTransform * item.bellotaTransform,
+            item.layer,
+            item.tintColor,
+            item.tintIntensity,
+            item.opacity
+        };
         drawParams.mode = texturePack.mode;
         if ((texturePack.mode == TextureMode::Indirect || texturePack.mode == TextureMode::TileMap)
             && texturePack.dpaletteTextureOpt.has_value())
@@ -279,6 +286,17 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
 {
     ZoneScopedN("runOneFrame");
 
+    const RenderSnapshot& snapshot = buildSnapshot(canvas, assets, imguiRtt, deltaTimeMS, update, controller);
+    renderSnapshot(assets, imguiRtt, snapshot, deltaTimeMS, controller);
+
+    FrameMark;
+}
+
+const RenderSnapshot& FrameRunner::buildSnapshot(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                                                 float deltaTimeMS, std::function<void(float)> update, Controller& controller)
+{
+    ZoneScopedN("buildSnapshot");
+
     {
         ZoneScopedN("Input");
         controller.processInputs();
@@ -291,10 +309,17 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
     // lazy font-texture re-upload picks up the rebuilt atlas.
     imguiRtt.drainPendingFontOps();
 
-    // Get current framebuffer size and compute letterboxed viewport
+    // Get current framebuffer size and compute letterboxed viewport. Stored so
+    // renderSnapshot can reuse the exact same values (one getFramebufferSize per
+    // frame). gameViewport() is read by user code during update (overlay
+    // positioning), so it must be set before update().
     auto [framebufferWidth, framebufferHeight] = mWindow->getFramebufferSize();
+    mFramebufferWidth = framebufferWidth;
+    mFramebufferHeight = framebufferHeight;
     mGameViewport = computeLetterboxViewport(framebufferWidth, framebufferHeight, mScreenSize.width, mScreenSize.height);
 
+    // M1: GPU-frame setup + ImGui NewFrame stay inline here (the user update
+    // issues ImGui calls). These migrate to the render side at the thread flip.
     mBackend.beginFrame(mClearColor, mGameViewport, framebufferWidth, framebufferHeight);
 
     // Start the Dear ImGui frame
@@ -318,13 +343,91 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
         mSparseLandManager.updateExplorers(canvas);
     }
 
-    const glm::mat3 worldTransformMat = computeWorldTransformMat(mScreenSize);
+    // Stamp this frame's commit number, then detect unused resources and enqueue
+    // them for deferred free (the actual GPU free happens in renderSnapshot, once
+    // no in-flight snapshot references them). At depth-0 this is the same frame.
+    mSnapshot.commitSeq = ++mCommitSeq;
+    mSnapshot.clearColor = mClearColor;
 
     if (mAutoTextureGC)
-        assets.clearUnusedTextures();
+        for (TextureId textureId : assets.collectUnusedTextures())
+            mPendingTextureFrees.push_back({textureId, mCommitSeq});
 
     if (mAutoMeshGC)
-        assets.clearUnusedMeshes();
+        for (MeshId meshId : assets.collectUnusedMeshes())
+            mPendingMeshFrees.push_back({meshId, mCommitSeq});
+
+    {
+        ZoneScopedN("DepthSort");
+        buildMainDraws(assets.bellotas(), mSnapshot.draws);
+    }
+
+    {
+        ZoneScopedN("RttGather");
+        buildRttPasses(assets, mSnapshot.rttPasses);
+    }
+
+    return mSnapshot;
+}
+
+void FrameRunner::buildRttPasses(AssetRegistry& assets, std::vector<RttPass>& out)
+{
+    out.clear();
+    for (auto& [renderTargetId, bellotaIds] : mPendingRttPasses)
+    {
+        RttPass pass;
+        pass.target = renderTargetId;
+        for (const BellotaId bellotaId : bellotaIds)
+        {
+            if (not assets.bellotas().contains(bellotaId.id)) continue;
+            const BellotaPack& pack = assets.bellotas().at(bellotaId.id);
+            if (not pack.bellota.visible()) continue;   // hidden ones never enter the sort
+            pass.draws.push_back(makeDrawItem(pack));
+        }
+        std::sort(pass.draws.begin(), pass.draws.end(),
+            [](const DrawItem& lhs, const DrawItem& rhs)
+            {
+                return lhs.depthOffset < rhs.depthOffset;
+            }
+        );
+        out.push_back(std::move(pass));
+    }
+    mPendingRttPasses.clear();
+}
+
+void FrameRunner::drainPendingFrees(AssetRegistry& assets, std::uint64_t lastRenderedSeq)
+{
+    std::erase_if(mPendingTextureFrees, [&](const PendingTextureFree& pending)
+    {
+        if (pending.retireSeq <= lastRenderedSeq)
+        {
+            assets.freeRetiredTexture(pending.id);
+            return true;
+        }
+        return false;
+    });
+    std::erase_if(mPendingMeshFrees, [&](const PendingMeshFree& pending)
+    {
+        if (pending.retireSeq <= lastRenderedSeq)
+        {
+            assets.freeRetiredMesh(pending.id);
+            return true;
+        }
+        return false;
+    });
+}
+
+void FrameRunner::renderSnapshot(AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                                 const RenderSnapshot& snapshot, float deltaTimeMS, Controller& controller)
+{
+    ZoneScopedN("renderSnapshot");
+
+    // Deferred free: release resources retired no later than the last fully
+    // rendered snapshot. At depth-0 (single thread) the snapshot we are about to
+    // render IS the latest commit, so frees happen this frame, before upload —
+    // identical timing to the old clearUnused* path.
+    mLastRenderedSeq = snapshot.commitSeq;
+    drainPendingFrees(assets, mLastRenderedSeq);
 
     {
         ZoneScopedN("TextureUpload");
@@ -344,21 +447,18 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
             meshPack.syncToGpu(mBackend);
     }
 
-    {
-        ZoneScopedN("DepthSort");
-        sortByDepthOffset(assets.bellotas(), mSortedBellotaPacks);
-    }
+    const glm::mat3 worldTransformMat = computeWorldTransformMat(mScreenSize);
 
     {
         ZoneScopedN("RttPasses");
-        // RTT pre-passes — render requested bellotas into their render targets
-        // before drawing to the main framebuffer.
-        for (auto& [renderTargetId, bellotaIds] : mPendingRttPasses)
+        // RTT pre-passes — render the snapshot's RTT draw lists into their render
+        // targets before drawing to the main framebuffer.
+        for (const RttPass& pass : snapshot.rttPasses)
         {
-            if (not assets.renderTargets().contains(renderTargetId.id))
+            if (not assets.renderTargets().contains(pass.target.id))
                 continue;
 
-            RenderTargetPack& renderTargetPack = assets.renderTargets().at(renderTargetId.id);
+            RenderTargetPack& renderTargetPack = assets.renderTargets().at(pass.target.id);
             if (not renderTargetPack.dRenderTargetOpt.has_value())
                 continue;
 
@@ -373,26 +473,10 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
             renderTargetWorldTransform = glm::scale(renderTargetWorldTransform,
                 glm::vec2(2.0f / renderTargetSize.x, 2.0f / renderTargetSize.y));
 
-            std::vector<const BellotaPack*> renderTargetSortedPacks;
-            for (const BellotaId bellotaId : bellotaIds)
-            {
-                if (not assets.bellotas().contains(bellotaId.id)) continue;
-                const BellotaPack& pack = assets.bellotas().at(bellotaId.id);
-                if (not pack.bellota.visible()) continue;   // hidden ones never enter the sort
-                renderTargetSortedPacks.push_back(&pack);
-            }
-            std::sort(renderTargetSortedPacks.begin(), renderTargetSortedPacks.end(),
-                [](const BellotaPack* lhs, const BellotaPack* rhs)
-                {
-                    return lhs->bellota.depthOffset() < rhs->bellota.depthOffset();
-                }
-            );
-
-            drawBellotaPacks(renderTargetSortedPacks, assets.textures(), assets.meshes(), renderTargetWorldTransform, mBackend);
+            drawItems(pass.draws, assets.textures(), assets.meshes(), renderTargetWorldTransform, mBackend);
 
             mBackend.endRttPass();
         }
-        mPendingRttPasses.clear();
 
         // ImGui-to-RTT passes — each uses a secondary ImGuiContext owned by the
         // render target, rendered with a pipeline compiled against the RTT render
@@ -405,7 +489,7 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
 
     {
         ZoneScopedN("MainDraw");
-        drawBellotaPacks(mSortedBellotaPacks, assets.textures(), assets.meshes(), worldTransformMat, mBackend);
+        drawItems(snapshot.draws, assets.textures(), assets.meshes(), worldTransformMat, mBackend);
     }
 
     if (mStats)
@@ -421,15 +505,13 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
     {
         ZoneScopedN("ImGuiRender");
         ImGui::Render();
-        mBackend.endFrame(ImGui::GetDrawData(), framebufferWidth, framebufferHeight);
+        mBackend.endFrame(ImGui::GetDrawData(), mFramebufferWidth, mFramebufferHeight);
     }
 
     {
         ZoneScopedN("SwapBuffers");
         mWindow->endFrame(controller, mScreenSize);
     }
-
-    FrameMark;
 }
 
 void FrameRunner::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
@@ -441,7 +523,7 @@ void FrameRunner::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& im
     mWindow->beginSession(controller);
     if (!mSessionStarted)
     {
-        mSortedBellotaPacks.reserve(assets.bellotas().size() * 2);
+        mSnapshot.draws.reserve(assets.bellotas().size() * 2);
         mSessionStarted = true;
     }
 

--- a/source/frame_runner.h
+++ b/source/frame_runner.h
@@ -5,12 +5,14 @@
 #include "sparse_land.h"
 #include "explorer.h"
 #include "explorer_manager.h"
-#include "bellota_container.h"   // for BellotaPack in mSortedBellotaPacks
+#include "bellota_container.h"
+#include "render_snapshot.h"
 #include "aa_box.h"
 #include "backends/render_backend_select.h"
 #include <vector>
 #include <utility>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <memory>
 
@@ -151,6 +153,34 @@ private:
     void ensureSessionStarted(Controller& controller);
     void runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
                      float deltaTimeMS, std::function<void(float)> update, Controller& controller);
+
+    /// Simulation/commit half of a frame: runs input + the user update +
+    /// explorers, detects unused resources (enqueuing them for deferred free),
+    /// and projects the live scene into the POD `mSnapshot` (depth-sorted main
+    /// draw list + RTT passes). Returns a reference to that snapshot.
+    ///
+    /// NOTE (Milestone 1): this also performs some GPU-frame setup inline
+    /// (`beginFrame`, ImGui `NewFrame`) because the user update issues ImGui
+    /// calls and reads `gameViewport()`. That setup migrates to the render side
+    /// at the thread-flip milestone; for now it stays here to keep the
+    /// single-threaded frame byte-identical.
+    const RenderSnapshot& buildSnapshot(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                                        float deltaTimeMS, std::function<void(float)> update, Controller& controller);
+
+    /// Render/consume half of a frame: drains deferred frees, uploads dirty GPU
+    /// resources, draws the snapshot's RTT passes and main pass, renders ImGui,
+    /// and presents. Touches no `Bellota` — only the POD snapshot.
+    void renderSnapshot(AssetRegistry& assets, ImguiRttManager& imguiRtt,
+                        const RenderSnapshot& snapshot, float deltaTimeMS, Controller& controller);
+
+    /// Gather the queued RTT passes (`mPendingRttPasses`) into POD draw lists on
+    /// `out` and clear the queue. CPU-only — GPU existence of each render target
+    /// is checked later, on the render side.
+    void buildRttPasses(AssetRegistry& assets, std::vector<RttPass>& out);
+
+    /// Free every pending resource whose retire commit is no later than
+    /// `lastRenderedSeq` (i.e. no in-flight snapshot still references it).
+    void drainPendingFrees(AssetRegistry& assets, std::uint64_t lastRenderedSeq);
     /// Apply the current effective content scale to the main ImGui context:
     /// FontScaleDpi (fonts, every frame) + ScaleAllSizes from the pristine base
     /// style (metrics, only when the scale changed). Main context must be current.
@@ -174,7 +204,21 @@ private:
     bool mSessionStarted{false}; ///< True after ensureSessionStarted() has been called.
     bool mAutoTextureGC{true}; ///< When true, unreferenced textures are removed each frame.
     bool mAutoMeshGC{true};    ///< When true, unreferenced meshes are removed each frame.
-    std::vector<const BellotaPack*> mSortedBellotaPacks; ///< Reusable depth-sorted draw list.
+
+    RenderSnapshot mSnapshot;  ///< Reused POD projection of the scene (produced by buildSnapshot, consumed by renderSnapshot).
+    std::uint64_t mCommitSeq{0};        ///< Monotonic commit counter; stamped onto each snapshot.
+    std::uint64_t mLastRenderedSeq{0};  ///< Highest commit seq fully rendered; gates deferred frees.
+
+    /// A resource removed from the scene at commit `retireSeq`, awaiting GPU free.
+    /// Held until `mLastRenderedSeq >= retireSeq` so no in-flight snapshot can
+    /// still reference it (at depth-0 this is the same frame).
+    struct PendingTextureFree { TextureId id; std::uint64_t retireSeq; };
+    struct PendingMeshFree    { MeshId    id; std::uint64_t retireSeq; };
+    std::vector<PendingTextureFree> mPendingTextureFrees;
+    std::vector<PendingMeshFree>    mPendingMeshFrees;
+
+    int mFramebufferWidth{0};   ///< Framebuffer size captured in buildSnapshot, reused by renderSnapshot.
+    int mFramebufferHeight{0};
 
     struct Window; ///< Forward declaration for window management.
     std::unique_ptr<Window> mWindow; ///< Pointer to the window object.

--- a/source/render_snapshot.h
+++ b/source/render_snapshot.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <vector>
+#include <cstdint>
+#include "texture_id.h"
+#include "mesh.h"           // MeshId
+#include "render_target.h"  // RenderTargetId
+
+namespace Nothofagus
+{
+
+/**
+ * @file render_snapshot.h
+ * @brief POD projection of the scene that the render side consumes.
+ *
+ * Part of the sim/render thread split (see
+ * notes/multithreading_design_discussion.md, option I). The simulation side
+ * mutates the live `Bellota` scene and, once per frame, *commits* it into a
+ * `RenderSnapshot` — a flat, trivially-copyable display list. The render side
+ * draws only from the snapshot and never touches a `Bellota`.
+ *
+ * In Milestone 1 the snapshot is built and consumed back-to-back on the same
+ * thread (`FrameRunner::buildSnapshot` → `renderSnapshot`), so it carries no
+ * concurrency cost yet; it exists to establish the POD data boundary. At the
+ * thread-flip milestone the snapshot becomes the double-buffered hand-off.
+ *
+ * Resources are referenced by id (`TextureId`/`MeshId`/`RenderTargetId`), never
+ * by GPU handle (`DTexture`/`DMesh`): a freshly created texture has no GPU
+ * handle at commit time, so ids are the only stable currency. The render side
+ * resolves id → handle *after* the per-frame GPU upload.
+ */
+
+/// One sprite to draw. `bellotaTransform` is the bellota-local transform
+/// (`bellota.transform().toMat3()`); the world transform is applied on the
+/// render side, so the same item can be drawn into both the main canvas and an
+/// RTT (which use different world transforms).
+struct DrawItem
+{
+    glm::mat3   bellotaTransform;
+    TextureId   texture;
+    MeshId      mesh;
+    int         layer;          ///< bellota.currentLayer()
+    glm::vec3   tintColor;
+    float       tintIntensity;
+    float       opacity;
+    std::int8_t depthOffset;    ///< retained for the depth sort / RTT gather
+};
+
+/// One render-to-texture pass: the display list to draw into `target`,
+/// already visible-filtered and depth-sorted at commit time.
+struct RttPass
+{
+    RenderTargetId        target;
+    std::vector<DrawItem> draws;
+};
+
+/// The full per-frame display list the render side consumes.
+struct RenderSnapshot
+{
+    std::uint64_t         commitSeq{0};   ///< monotonic commit counter; the deferred-free clock
+    std::vector<DrawItem> draws;          ///< main pass, depth-sorted at commit
+    std::vector<RttPass>  rttPasses;      ///< insertion order preserved (nested-RTT dependency)
+    glm::vec3             clearColor{0.0f};
+};
+
+}


### PR DESCRIPTION
First step toward a sim/render thread split: invert the frame loop so it
**produces a POD snapshot of the scene, then consumes it**, instead of drawing
directly from live `Bellota`s mid-frame. This milestone keeps everything on one
thread — it establishes the data boundary and the deferred-resource-free
plumbing with zero concurrency, so the later thread flip is a small change rather
than a rewrite.

`canvas.run()` / `canvas.tick()` behavior is unchanged; this is an internal
refactor of `FrameRunner` plus supporting `AssetRegistry` methods. No public API
changes.

## Motivation

`FrameRunner::runOneFrame` ran the user `update(dt)` callback *inside* the GL
frame and uploaded the bellotas it mutated a few lines later. That tight coupling
blocks ever moving simulation off the render thread. The target architecture
is: a sim side mutates the scene and **commits** a frame snapshot; a render side
draws the **previous** snapshot; GPU resources are freed only once no in-flight
snapshot still references them.

This PR introduces that seam while staying single-threaded.

## What changed

- **New `source/render_snapshot.h`** — POD projection of the scene the render
  side consumes:
  - `DrawItem` — bellota-local transform + `TextureId`/`MeshId` + tint / opacity
    / layer / depth. Resources are referenced **by id, not GPU handle** (a
    freshly created texture has no `DTexture` at commit time; the render side
    resolves id → handle after upload).
  - `RttPass` — render-target id + its visible-filtered, depth-sorted draw list.
  - `RenderSnapshot` — `commitSeq` (the deferred-free clock) + main draws + RTT
    passes + clear color.

- **`FrameRunner` split** (`source/frame_runner.{h,cpp}`) — `runOneFrame` is now
  `buildSnapshot(...)` → `renderSnapshot(...)`:
  - `buildSnapshot` (produce): input, ImGui `NewFrame`, `update(dt)`, explorers,
    detect-unused-and-enqueue, then projects the live scene into a reused
    `mSnapshot` (depth-sorted main draws + RTT passes).
  - `renderSnapshot` (consume): drains deferred frees, uploads dirty GPU
    resources, draws the snapshot's RTT + main passes, renders ImGui, presents.
    Touches no `Bellota` — only the POD snapshot.
  - The old `drawBellotaPacks` / `makeSpriteDrawParams` / `sortByDepthOffset`
    (pointer-into-live-container helpers) are replaced by `drawItems` /
    `makeDrawItem` / `buildMainDraws` over POD. `mSortedBellotaPacks` removed.

- **Deferred resource removal** (`source/asset_registry.{h,cpp}`) — splits the
  old immediate `clearUnusedTextures` / `clearUnusedMeshes` into detect and free:
  - `collectUnusedTextures` / `collectUnusedMeshes` — detect unreferenced
    resources and clear them from the usage monitor, **without** freeing GPU
    resources (same monitor side effects as the old `clearUnused*`, incl. proxy
    skipping).
  - `freeRetiredTexture` / `freeRetiredMesh` — free GPU resources + erase from
    the container (monitor already updated by the collect step).
  - `FrameRunner` queues retired ids with `retireSeq = commitSeq` and frees them
    only once `retireSeq <= lastRenderedSeq`. At this depth-0 (single thread)
    `lastRenderedSeq == commitSeq`, so frees happen the same frame, before
    upload — **identical timing to the previous code**. The gate is the exact
    mechanism the thread flip will rely on.

## Notes / scope

- ImGui and the dense/sparse explorers stay inline on the one thread for now
  (explorers now run inside `buildSnapshot`, before the scene is projected).
  Both move to the sim side at the thread-flip milestone.
- RTT passes deliberately ride in the **same** snapshot (no extra-frame
  deferral): the render side already executes RTT → main → present in order, so
  RTT inherits the same uniform latency as the sprites committed alongside it.