### PR TITLE
Render GFM tables with native ImGui tables

### DIFF
--- a/third_party/imgui_md/imgui_md.cpp
+++ b/third_party/imgui_md/imgui_md.cpp
@@ -55,10 +55,6 @@ imgui_md::imgui_md()
 
 	m_md.syntax = nullptr;
 
-	////////////////////////////////////////////////////////////////////////////
-
-	m_table_last_pos = ImVec2(0, 0);
-
 }
 
 
@@ -163,61 +159,26 @@ void imgui_md::BLOCK_P(bool)
 	ImGui::NewLine();
 }
 
-void imgui_md::BLOCK_TABLE(const MD_BLOCK_TABLE_DETAIL*, bool e)
+void imgui_md::BLOCK_TABLE(const MD_BLOCK_TABLE_DETAIL* d, bool e)
 {
 	if (e) {
-		m_table_row_pos.clear();
-		m_table_col_pos.clear();
+		// Salt the id by the source-buffer address and a per-document index so
+		// several tables — and repeated print() calls into one window — never
+		// share an ImGui id. PushID is unconditional, so PopID must be too.
+		ImGui::PushID((const void*)m_doc_start);
+		ImGui::PushID(m_table_index);
+		++m_table_index;
 
-		m_table_last_pos = ImGui::GetCursorPos();
+		ImGuiTableFlags flags = ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_RowBg;
+		if (m_table_border) flags |= ImGuiTableFlags_Borders;
+
+		m_table_active = ImGui::BeginTable("md_table", (int)d->col_count, flags);
 	} else {
-
-		ImGui::NewLine();
-
-		if (m_table_border) {
-
-			m_table_last_pos.y = ImGui::GetCursorPos().y;
-
-			m_table_col_pos.push_back(m_table_last_pos.x);
-			m_table_row_pos.push_back(m_table_last_pos.y);
-
-			const ImVec2 wp = ImGui::GetWindowPos();
-			const ImVec2 sp = ImGui::GetStyle().ItemSpacing;
-			const float wx = wp.x + sp.x / 2;
-			const float wy = wp.y - sp.y / 2 - ImGui::GetScrollY();
-
-			for (int i = 0; i < m_table_col_pos.size(); ++i) {
-				m_table_col_pos[i] += wx;
-			}
-
-			for (int i = 0; i < m_table_row_pos.size(); ++i) {
-				m_table_row_pos[i] += wy;
-			}
-
-			////////////////////////////////////////////////////////////////////
-
-			const ImColor c = ImGui::GetStyle().Colors[ImGuiCol_TextDisabled];
-
-			ImDrawList* dl = ImGui::GetWindowDrawList();
-
-			const float xmin = m_table_col_pos.front();
-			const float xmax = m_table_col_pos.back();
-			for (int i = 0; i < m_table_row_pos.size(); ++i) {
-				const float p = m_table_row_pos[i];
-				dl->AddLine(ImVec2(xmin, p), ImVec2(xmax, p), c, 
-					i == 1 && m_table_header_highlight ? 2.0f : 1.0f);
-			}
-
-			const float ymin = m_table_row_pos.front();
-			const float ymax = m_table_row_pos.back();
-			for (int i = 0; i < m_table_col_pos.size(); ++i) {
-				const float p = m_table_col_pos[i];
-				dl->AddLine(ImVec2(p, ymin), ImVec2(p, ymax), c, 1.0f);
-			}
-		}
+		if (m_table_active) ImGui::EndTable();
+		m_table_active = false;
+		ImGui::PopID();
+		ImGui::PopID();
 	}
-
-
 }
 
 void imgui_md::BLOCK_THEAD(bool e)
@@ -233,51 +194,17 @@ void imgui_md::BLOCK_TBODY(bool e)
 
 void imgui_md::BLOCK_TR(bool e)
 {
-	ImGui::SetCursorPosY(m_table_last_pos.y);
-
-	if (e) {
-		m_table_next_column = 0;
-		ImGui::NewLine();
-		m_table_row_pos.push_back(ImGui::GetCursorPosY());
-	}
+	if (e && m_table_active) ImGui::TableNextRow();
 }
 
 void imgui_md::BLOCK_TH(const MD_BLOCK_TD_DETAIL* d, bool e)
 {
 	BLOCK_TD(d, e);
-
 }
 
 void imgui_md::BLOCK_TD(const MD_BLOCK_TD_DETAIL*, bool e)
 {
-	if (e) {
-
-		if (m_table_next_column < m_table_col_pos.size()) {
-			ImGui::SetCursorPosX(m_table_col_pos[m_table_next_column]);
-		} else {
-			m_table_col_pos.push_back(m_table_last_pos.x);
-		}
-
-		++m_table_next_column;
-
-		ImGui::Indent(m_table_col_pos[m_table_next_column - 1]);
-		ImGui::SetCursorPos(
-			ImVec2(m_table_col_pos[m_table_next_column - 1], m_table_row_pos.back()));
-
-	} else {
-		const ImVec2 p = ImGui::GetCursorPos();
-		ImGui::Unindent(m_table_col_pos[m_table_next_column - 1]);
-		ImGui::SetCursorPosX(p.x);
-		if (p.y > m_table_last_pos.y)m_table_last_pos.y = p.y;
-	}
-	ImGui::TextUnformatted(""); 
-	
-	if (!m_table_border && e && m_table_next_column==1 ) {
-		ImGui::SameLine(0.0f, 0.0f);
-	} else {
-		ImGui::SameLine();
-	}
-	
+	if (e && m_table_active) ImGui::TableNextColumn();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -423,13 +350,9 @@ void imgui_md::render_text(const char* str, const char* str_end)
 
 		if (!m_is_table_header) {
 
+			// Wrap to the width still available where the cursor sits — inside a
+			// table column that is the column's width, so cells wrap to fit.
 			float wl = ImGui::GetContentRegionAvail().x;
-
-			if (m_is_table_body) {
-				wl = (m_table_next_column < m_table_col_pos.size() ?
-					m_table_col_pos[m_table_next_column] : m_table_last_pos.x);
-				wl -= ImGui::GetCursorPosX();
-			}
 
 			// ImGui 1.92 renders text at GetFontSize() (= size * FontScaleMain *
 			// FontScaleDpi). Wrap at that same size so the layout matches the
@@ -639,11 +562,6 @@ int imgui_md::text(MD_TEXTTYPE type, const char* str, const char* str_end)
 		break;
 	}
 
-	if (m_is_table_header) {
-		const float x = ImGui::GetCursorPosX();
-		if (x > m_table_last_pos.x)m_table_last_pos.x = x;
-	}
-
 	return 0;
 }
 
@@ -752,6 +670,8 @@ int imgui_md::span(MD_SPANTYPE type, void* d, bool e)
 int imgui_md::print(const char* str, const char* str_end)
 {
 	if (str >= str_end)return 0;
+	m_doc_start = str;   // salt table ids; print() may run several times into one window
+	m_table_index = 0;
 	return md_parse(str, (MD_SIZE)(str_end - str), &m_md, this);
 }
 

--- a/third_party/imgui_md/imgui_md.h
+++ b/third_party/imgui_md/imgui_md.h
@@ -140,10 +140,9 @@ private:
 	static void line(ImColor c, bool under);
 
 	//table state
-	int m_table_next_column = 0;
-	ImVec2 m_table_last_pos;
-	std::vector<float> m_table_col_pos;
-	std::vector<float> m_table_row_pos;
+	bool m_table_active = false;        //BeginTable succeeded for the current table
+	int m_table_index = 0;              //per-document table counter, for unique ids
+	const char* m_doc_start = nullptr;  //start of the buffer passed to the current print()
 
 	//list state
 	struct list_info


### PR DESCRIPTION
Table rendering used a hand-rolled layout: every column was placed at an
x-position derived from the **header row's** content width, and the borders were
drawn manually with `ImDrawList::AddLine`. Tables whose headers are short but
whose body cells are long collapsed the column to a few pixels, so cell text
wrapped one glyph per line and spilled over neighbouring columns.

This replaces that layout with Dear ImGui's native table API
(`BeginTable` / `TableNextRow` / `TableNextColumn` / `EndTable`), which sizes
columns proportionally and wraps each cell to its real column width.

## Why this works

md4c already supplies what the native API needs:

- `MD_BLOCK_TABLE_DETAIL.col_count` is available when the table block opens.
- The callback order (`THEAD → TR → TH…`, `TBODY → TR → TD…`) maps 1:1 onto
  `TableNextRow` / `TableNextColumn`.

Inside a native table column, `GetContentRegionAvail().x` *is* the column width,
so the existing word-wrap path in `render_text` wraps cells correctly once the
old table-specific width override is removed — no new wrapping logic needed.

## Changes

- **`BLOCK_TABLE`** — open/close a real table. Flags: `SizingStretchProp |
  RowBg`, plus `Borders` when `m_table_border` is set. `EndTable` is only called
  when `BeginTable` returned true.
- **`BLOCK_TR` / `BLOCK_TD`** — `TableNextRow` / `TableNextColumn`.
- **`BLOCK_THEAD`** — unchanged: still pushes the highlight font when
  `m_table_header_highlight`, so the header row stays bold.
- **`render_text`** — drop the table-body width override; wrap to
  `GetContentRegionAvail().x` (the live column width).
- **`print`** — record the buffer start and reset a per-document table counter.
  Table ids are salted by the source-buffer address plus that counter, so
  several tables — and repeated `print()` calls into the same window — never
  share an ImGui id.
- Removed the manual layout state (`m_table_col_pos`, `m_table_row_pos`,
  `m_table_last_pos`, `m_table_next_column`) and the manual border drawing.

## Testing

Rendered tables with short headers and long body cells into a narrow window:
columns size proportionally, long cells wrap inside their own column (no
per-glyph stacking or spill), the header row stays bold, and borders line up
across rows. Plain (all-short-cell) tables render unchanged.

## Limitations

- Per-cell horizontal alignment (`MD_BLOCK_TD_DETAIL.align`) is not applied;
  ImGui has no one-call per-cell text alignment. Left as a follow-up.
