### PR TITLE
User-set target FPS (frame-rate limiter)

### DIFF
--- a/include/canvas.h
+++ b/include/canvas.h
@@ -87,6 +87,8 @@ public:
      * @param presentMode Swapchain / vsync preference (default Mailbox). Set at
      *        construction only; affects windowed builds (Vulkan present mode and
      *        OpenGL swap interval). Ignored in pure-offscreen headless-Vulkan builds.
+     * @param targetFps Optional frame-rate cap for run() (std::nullopt = unlimited,
+     *        the default). See setTargetFps for semantics.
      */
     Canvas(
         const ScreenSize& screenSize = DEFAULT_SCREEN_SIZE,
@@ -95,7 +97,8 @@ public:
         const unsigned int pixelSize = DEFAULT_PIXEL_SIZE,
         const float imguiFontSize = DEFAULT_IMGUI_FONT_SIZE,
         bool headless = false,
-        PresentMode presentMode = DEFAULT_PRESENT_MODE
+        PresentMode presentMode = DEFAULT_PRESENT_MODE,
+        std::optional<float> targetFps = std::nullopt
     );
 
     /// Destructor
@@ -119,6 +122,21 @@ public:
     void setScreenSize(const ScreenSize& screenSize);
 
     void setClearColor(glm::vec3 clearColor);
+
+    /// @brief Caps the run() loop to at most `targetFps` frames per second.
+    ///
+    /// Pass std::nullopt (or a value <= 0) to remove the cap (unlimited — the default).
+    /// Runtime-settable: takes effect within a frame. Only affects run(); tick() is
+    /// caller-driven and never throttled.
+    ///
+    /// Most useful with a non-blocking present mode (Vulkan Mailbox/Immediate, OpenGL
+    /// Immediate). Under hard vsync (Fifo, or OpenGL swap interval 1) the loop is already
+    /// blocked at the display refresh, so a cap above refresh does nothing and a cap below
+    /// it competes with vsync.
+    void setTargetFps(std::optional<float> targetFps);
+
+    /// The current frame-rate cap, or std::nullopt when unlimited.
+    std::optional<float> targetFps() const;
 
     void setWindowTitle(const std::string& title);
 

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -69,8 +69,9 @@ struct Canvas::Implementation
         const unsigned int pixelSize,
         const float imguiFontSize,
         bool headless,
-        PresentMode presentMode)
-        : frameRunner(screenSize, title, clearColor, pixelSize, headless, presentMode),
+        PresentMode presentMode,
+        std::optional<float> targetFps)
+        : frameRunner(screenSize, title, clearColor, pixelSize, headless, presentMode, targetFps),
           assets(frameRunner.backend()),
           imguiRtt(frameRunner.backend(), assets.renderTargets(),
                    makeEmbeddedFontFamily(),
@@ -97,10 +98,11 @@ Canvas::Canvas(
     const unsigned int pixelSize,
     const float imguiFontSize,
     bool headless,
-    PresentMode presentMode
+    PresentMode presentMode,
+    std::optional<float> targetFps
 )
     : mImplPtr(std::make_unique<Implementation>(
-          screenSize, title, clearColor, pixelSize, imguiFontSize, headless, presentMode))
+          screenSize, title, clearColor, pixelSize, imguiFontSize, headless, presentMode, targetFps))
 {
 }
 
@@ -126,6 +128,8 @@ void Canvas::setWindowed()                                       { mImplPtr->fra
 const ScreenSize& Canvas::screenSize() const                    { return mImplPtr->frameRunner.screenSize(); }
 void Canvas::setScreenSize(const ScreenSize& screenSize)        { mImplPtr->frameRunner.setScreenSize(screenSize); }
 void Canvas::setClearColor(glm::vec3 clearColor)                { mImplPtr->frameRunner.setClearColor(clearColor); }
+void Canvas::setTargetFps(std::optional<float> targetFps)       { mImplPtr->frameRunner.setTargetFps(targetFps); }
+std::optional<float> Canvas::targetFps() const                  { return mImplPtr->frameRunner.targetFps(); }
 void Canvas::setAutoRemoveUnusedTextures(bool enabled)          { mImplPtr->frameRunner.setAutoRemoveUnusedTextures(enabled); }
 void Canvas::setAutoRemoveUnusedMeshes(bool enabled)            { mImplPtr->frameRunner.setAutoRemoveUnusedMeshes(enabled); }
 void Canvas::setWindowTitle(const std::string& title)           { mImplPtr->frameRunner.setWindowTitle(title); }

--- a/source/frame_runner.cpp
+++ b/source/frame_runner.cpp
@@ -23,6 +23,8 @@
 #include <span>
 #include <format>
 #include <algorithm>
+#include <chrono>
+#include <thread>
 #include "profiling.h"
 
 namespace Nothofagus
@@ -41,13 +43,15 @@ FrameRunner::FrameRunner(
     const glm::vec3 clearColor,
     const unsigned int pixelSize,
     bool headless,
-    PresentMode presentMode)
+    PresentMode presentMode,
+    std::optional<float> targetFps)
     :
     mScreenSize(screenSize),
     mTitle(title),
     mClearColor(clearColor),
     mPixelSize(pixelSize),
     mPresentMode(presentMode),
+    mTargetFps((targetFps && *targetFps > 0.0f) ? targetFps : std::nullopt),
     mStats(false),
     mHeadless(headless),
     mGameViewport{0, 0, 0, 0}
@@ -549,11 +553,50 @@ void FrameRunner::run(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& im
 
     PerformanceMonitor performanceMonitor(mWindow->getTime(), 0.5f);
 
+    // Frame-rate limiter deadline. steady_clock (monotonic, integer-based) is used
+    // instead of the backend's float getTime() so the deadline never drifts over a
+    // long session; float is reserved for the small per-frame dt below.
+    auto nextDeadline = std::chrono::steady_clock::now();
+
     while (mWindow->isRunning())
     {
         performanceMonitor.update(mWindow->getTime());
         runOneFrame(canvas, assets, imguiRtt, imguiImages, performanceMonitor.getMS(), update, controller);
+        limitFrameRate(nextDeadline);
     }
+}
+
+void FrameRunner::limitFrameRate(std::chrono::steady_clock::time_point& nextDeadline)
+{
+    using namespace std::chrono;
+
+    if (!mTargetFps)
+    {
+        // Unlimited: keep the deadline anchored to now so that enabling a cap mid-run
+        // starts pacing from the current frame instead of firing a catch-up burst.
+        nextDeadline = steady_clock::now();
+        return;
+    }
+
+    const auto period = duration_cast<steady_clock::duration>(duration<double>(1.0 / *mTargetFps));
+    nextDeadline += period;
+
+    const auto now = steady_clock::now();
+    if (now >= nextDeadline)
+    {
+        // Behind schedule (heavy frame, or the cap was just lowered): resync to now so we
+        // never try to "catch up" by running a burst of zero-length frames.
+        nextDeadline = now;
+        return;
+    }
+
+    // Hybrid wait: sleep most of the remaining time, then busy-spin the last ~1 ms for a
+    // crisp deadline (OS sleep granularity alone overshoots by 1-15 ms).
+    constexpr auto spinMargin = milliseconds(1);
+    if (nextDeadline - now > spinMargin)
+        std::this_thread::sleep_until(nextDeadline - spinMargin);
+    while (steady_clock::now() < nextDeadline)
+        std::this_thread::yield();
 }
 
 void FrameRunner::tick(Canvas& canvas, AssetRegistry& assets, ImguiRttManager& imguiRtt,

--- a/source/frame_runner.h
+++ b/source/frame_runner.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <optional>
 #include <memory>
+#include <chrono>
 
 struct ImGuiStyle; // global-scope (Dear ImGui); held by unique_ptr to keep imgui.h out of this header.
 
@@ -62,7 +63,8 @@ public:
         const glm::vec3 clearColor,
         const unsigned int pixelSize,
         bool headless = false,
-        PresentMode presentMode = DEFAULT_PRESENT_MODE
+        PresentMode presentMode = DEFAULT_PRESENT_MODE,
+        std::optional<float> targetFps = std::nullopt
     );
 
     /// Destructor to clean up resources and terminate the window backend.
@@ -109,6 +111,9 @@ public:
     const ScreenSize& screenSize() const                                                    { return mScreenSize; }
     void setScreenSize(const ScreenSize& screenSize)                                        { mScreenSize = screenSize; }
     void setClearColor(glm::vec3 clearColor)                                                { mClearColor = clearColor; }
+    /// Frame-rate cap for run(); a present value <= 0 is normalized to nullopt (unlimited).
+    void setTargetFps(std::optional<float> targetFps)                                       { mTargetFps = (targetFps && *targetFps > 0.0f) ? targetFps : std::nullopt; }
+    std::optional<float> targetFps() const                                                  { return mTargetFps; }
     ViewportRect gameViewport() const                                                       { return mGameViewport; }
     bool& stats()                                                                           { return mStats; }
     const bool& stats() const                                                               { return mStats; }
@@ -193,6 +198,11 @@ private:
     /// style (metrics, only when the scale changed). Main context must be current.
     void applyMainContextScale();
 
+    /// If a target FPS is set, wait until `nextDeadline` (hybrid sleep + short busy-spin)
+    /// and advance it by one frame period; otherwise just refresh `nextDeadline` to now.
+    /// Uses steady_clock directly (monotonic, no float drift over long sessions).
+    void limitFrameRate(std::chrono::steady_clock::time_point& nextDeadline);
+
     ScreenSize mScreenSize; ///< The screen size of the canvas.
     std::string mTitle; ///< The title of the canvas window.
     glm::vec3 mClearColor; ///< The background color of the canvas.
@@ -207,6 +217,7 @@ private:
     std::vector<std::pair<RenderTargetId, std::vector<BellotaId>>> mPendingRttPasses;
 
     PresentMode mPresentMode{DEFAULT_PRESENT_MODE}; ///< Swapchain / vsync preference (construction-time).
+    std::optional<float> mTargetFps; ///< Frame-rate cap for run() (nullopt = unlimited). Runtime-settable.
     bool mStats; ///< Flag to indicate whether stats should be displayed.
     bool mHeadless{false}; ///< When true, the window is hidden (no visible UI).
     bool mSessionStarted{false}; ///< True after ensureSessionStarted() has been called.


### PR DESCRIPTION
Adds an optional, user-settable **target FPS** that caps how often the `run()` loop
iterates. Follow-up to the present-mode PR (#106): now that the windowed loop is no longer
vsync-pinned (`Mailbox`/`Immediate` let it run at thousands of fps), apps need a way to
**bound** the frame rate — to save CPU/GPU/battery or lock to a deliberate cadence (e.g.
60 or 30).

The cap is **construction-time *and* runtime settable**, defaults to **unlimited** (no
behavior change unless opted in), and is implemented as **backend-agnostic CPU loop
timing** — one implementation, identical for OpenGL and Vulkan, with no backend changes.

## API

```cpp
// Construction (trailing optional arg; std::nullopt = unlimited):
Nothofagus::Canvas canvas({256, 240}, "App", {0, 0, 0}, 4, 14.0f,
                          /*headless=*/false, Nothofagus::PresentMode::Mailbox,
                          /*targetFps=*/60.0f);

// Runtime — takes effect within a frame:
canvas.setTargetFps(30.0f);          // cap to 30
canvas.setTargetFps(std::nullopt);   // remove the cap (unlimited)
std::optional<float> current = canvas.targetFps();
```

`nullopt` (or any value `<= 0`) means unlimited; the value is normalized in one place.

## Implementation

- **Clock:** the limiter uses `std::chrono::steady_clock` directly — monotonic, integer
  nanoseconds, so the frame deadline never drifts regardless of session length. The window
  backend's `getTime()` (float seconds-since-init) is deliberately *not* used for the
  deadline; float stays confined to the small per-frame `dt`.
- **Wait strategy:** deadline-based, hybrid **sleep + spin** — `sleep_until(deadline − ~1ms)`
  then a short busy-spin (`yield`) to the exact deadline. OS sleep granularity alone
  overshoots by 1–15 ms; the spin makes the cap crisp (a true 60.0).
- **No catch-up bursts:** if a frame overruns the budget (heavy frame, or the cap was just
  lowered), the deadline resyncs to *now* instead of firing a burst of zero-length frames.
  When unlimited, the deadline is kept anchored to *now* so enabling a cap mid-run starts
  pacing cleanly.
- **Scope:** only `run()` is throttled. `tick()` is caller-driven manual stepping and is
  left untouched; headless/offscreen is unaffected.
- **Threading the value:** `Canvas → Canvas::Implementation → FrameRunner`, mirroring the
  `presentMode` chain; `setTargetFps`/`targetFps` forward to `FrameRunner` like the other
  state setters (`setClearColor`, `stats()`).

## Interaction with present mode / vsync (documented in `setTargetFps`)

The cap is most meaningful with a non-blocking present mode — Vulkan `Mailbox`/`Immediate`
or OpenGL `Immediate`. Under hard vsync (`Fifo`, or OpenGL swap interval 1) the loop is
already blocked at the display refresh, so a cap *above* refresh does nothing and a cap
*below* it competes with vsync. The clean pairing is **Mailbox + target FPS** on Vulkan:
no tearing *and* bounded resource use.

## Verification

Built clean on all three example backends (glfw-opengl, glfw-vulkan, sdl3-vulkan). A
throwaway bench (since removed) measured **steady-state** FPS (excluding window/GPU
startup) on a live display:

| Target | Vulkan (Mailbox) | OpenGL (Immediate) |
|--------|------------------|--------------------|
| unlimited | 2821 fps | 7782 fps |
| 30  | 29.6 | 30.0 |
| 60  | 60.0 | 59.9 |
| 120 | 119.9 | 118.5 |
| 144 | 144.0 | — |

Caps land on target on both backends; the unlimited default is unchanged. The runtime
setter is a per-frame read of the cap, so live changes take effect within a frame.