### PR TITLE
Fix two pre-existing Vulkan validation errors (windowed backend)

### DIFF
--- a/source/backends/vulkan_backend.cpp
+++ b/source/backends/vulkan_backend.cpp
@@ -420,6 +420,20 @@ void VulkanBackend::initialize(void* nativeWindowHandle, glm::ivec2 canvasSize, 
         dep.srcAccessMask = 0;
         dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 
+        // Order this frame's depth access after the previous frame's depth write. The depth
+        // image is shared across frames, so without this the next frame's clear / layout
+        // transition races the prior frame's write (SYNC-HAZARD-WRITE-AFTER-WRITE).
+        VkSubpassDependency depthDep{};
+        depthDep.srcSubpass    = VK_SUBPASS_EXTERNAL;
+        depthDep.dstSubpass    = 0;
+        depthDep.srcStageMask  = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+        depthDep.dstStageMask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+        depthDep.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        depthDep.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+                                 VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+
+        std::array<VkSubpassDependency, 2> dependencies = {dep, depthDep};
+
         std::array<VkAttachmentDescription, 2> attachments = {colorAttachment, depthAttachment};
         VkRenderPassCreateInfo rpInfo{};
         rpInfo.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -427,8 +441,8 @@ void VulkanBackend::initialize(void* nativeWindowHandle, glm::ivec2 canvasSize, 
         rpInfo.pAttachments    = attachments.data();
         rpInfo.subpassCount    = 1;
         rpInfo.pSubpasses      = &subpass;
-        rpInfo.dependencyCount = 1;
-        rpInfo.pDependencies   = &dep;
+        rpInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
+        rpInfo.pDependencies   = dependencies.data();
 
         if (vkCreateRenderPass(mDevice, &rpInfo, nullptr, &mMainRenderPass) != VK_SUCCESS)
             throw std::runtime_error("Failed to create main render pass");
@@ -473,6 +487,19 @@ void VulkanBackend::initialize(void* nativeWindowHandle, glm::ivec2 canvasSize, 
         dep.srcAccessMask = 0;
         dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 
+        // Order this frame's depth access after the previous frame's depth write: each RTT
+        // reuses its own depth image every frame it is rendered, so the same WAW applies.
+        VkSubpassDependency depthDep{};
+        depthDep.srcSubpass    = VK_SUBPASS_EXTERNAL;
+        depthDep.dstSubpass    = 0;
+        depthDep.srcStageMask  = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+        depthDep.dstStageMask  = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+        depthDep.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        depthDep.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+                                 VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+
+        std::array<VkSubpassDependency, 2> dependencies = {dep, depthDep};
+
         std::array<VkAttachmentDescription, 2> attachments = {colorAttachment, depthAttachment};
         VkRenderPassCreateInfo rpInfo{};
         rpInfo.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -480,8 +507,8 @@ void VulkanBackend::initialize(void* nativeWindowHandle, glm::ivec2 canvasSize, 
         rpInfo.pAttachments    = attachments.data();
         rpInfo.subpassCount    = 1;
         rpInfo.pSubpasses      = &subpass;
-        rpInfo.dependencyCount = 1;
-        rpInfo.pDependencies   = &dep;
+        rpInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
+        rpInfo.pDependencies   = dependencies.data();
 
         if (vkCreateRenderPass(mDevice, &rpInfo, nullptr, &mRttRenderPass) != VK_SUCCESS)
             throw std::runtime_error("Failed to create RTT render pass");

--- a/source/backends/vulkan_presentation.cpp
+++ b/source/backends/vulkan_presentation.cpp
@@ -125,6 +125,7 @@ void WindowedVulkanPresentation::createPresentationTarget(
         .add_fallback_format({VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR})
         .set_desired_present_mode(mPresentMode)               // vk-bootstrap falls back to FIFO if unsupported.
         .set_desired_min_image_count(kDesiredSwapchainImageCount)
+        .add_image_usage_flags(VK_IMAGE_USAGE_TRANSFER_SRC_BIT) // takeScreenshot() blits from the swapchain image.
         .set_desired_extent(framebufferSize.width, framebufferSize.height)
         .build();
     if (!swapchainResult)
@@ -538,6 +539,7 @@ void WindowedVulkanPresentation::recreateSwapchain()
         .add_fallback_format({VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR})
         .set_desired_present_mode(mPresentMode)               // Preserve the mode chosen at init across recreation.
         .set_desired_min_image_count(kDesiredSwapchainImageCount)
+        .add_image_usage_flags(VK_IMAGE_USAGE_TRANSFER_SRC_BIT) // takeScreenshot() blits from the swapchain image.
         .set_desired_extent(framebufferSize.width, framebufferSize.height)
         .set_old_swapchain(mSwapchain)
         .build();


### PR DESCRIPTION
Two spec violations surfaced by `present_mode_sync_tests` under the validation layers.
Both predate the present-mode work and were tolerated by AMD/NVIDIA. Headless was already
correct. No public API / OpenGL / headless changes; rendered output unchanged.

## Fix A — swapchain blitted without `TRANSFER_SRC`
`takeScreenshot` blits from the swapchain image, but the swapchain used vk-bootstrap's
default usage (`COLOR_ATTACHMENT` only). → `VUID-vkCmdBlitImage-srcImage-00219`,
`VUID-VkImageMemoryBarrier-oldLayout-01212`.

Added `.add_image_usage_flags(VK_IMAGE_USAGE_TRANSFER_SRC_BIT)` to both `SwapchainBuilder`
chains in `source/backends/vulkan_presentation.cpp` (matches the headless image).

## Fix B — depth WRITE-AFTER-WRITE across frames
The shared depth image is reused every frame, but the render pass's only dependency had
`srcAccessMask = 0` / no `LATE_FRAGMENT_TESTS`, so consecutive frames' depth writes weren't
ordered. → `SYNC-HAZARD-WRITE-AFTER-WRITE`.

Added a depth-dedicated subpass dependency (`LATE_FRAGMENT_TESTS`/`DEPTH_WRITE` →
`EARLY_FRAGMENT_TESTS`/`DEPTH_WRITE|READ`) to the main and RTT render passes in
`source/backends/vulkan_backend.cpp`.

## Verification
- Windowed + headless Vulkan build clean.
- Both target ids gone under validation; `present_mode_sync_tests` passes.
- `present_mode_pixel_tests` and the SwiftShader golden suite pass unchanged (no pixel diff).

## Out of scope
A subtler `SYNC-HAZARD-WRITE-AFTER-PRESENT` remains, left for a follow-up.