### PR TITLE
Request and retrieve screenshot for safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ source/backends/
 | `acquireImage()` | `beginFrame()` | vkAcquireNextImageKHR or no-op (always succeeds) |
 | `mainFramebuffer()` / `extent()` | `beginMainPass()` | Return the active framebuffer and render area |
 | `submitAndPresent()` | `endFrame()` | Submit + present with semaphores, or submit with fence only |
-| `takeScreenshot()` | `takeScreenshot()` | Copy pixels from swapchain or offscreen image to CPU |
+| `recordCapture()` / `finishCapture()` | `endFrame()` / `finishScreenshot()` | Record the scheduled screenshot copy in-frame before present, then read it back after the fence |
 | `shutdown()` | `shutdown()` | Destroy surface/swapchain or offscreen resources |
 
 **Initialization order** (critical — render pass depends on format from the presentation target):
@@ -201,8 +201,10 @@ for (int i = 0; i < 10; ++i)
 canvas.tick(16.0f, [&](float dt) { /* update logic */ }, controller);
 canvas.tick(16.0f, [&](float dt) { /* update logic */ });
 
-// Screenshot works in headless mode:
-Nothofagus::DirectTexture screenshot = canvas.takeScreenshot();
+// Screenshot works in headless mode (scheduled: request, render a frame, retrieve):
+canvas.requestScreenshot();
+canvas.tick(16.0f);
+Nothofagus::DirectTexture screenshot = *canvas.retrieveScreenshot();
 ```
 
 GPU resources are cleaned up automatically in the `Canvas` destructor — no need to call `run()` or any explicit shutdown. Call `canvas.close()` from inside an update callback to break out of `run()` early.
@@ -868,11 +870,25 @@ Gamepad button events are dispatched in `processInputs()` (same frame-deferred p
 
 ### Screenshot
 
-`takeScreenshot()` captures the most recently rendered frame and returns a `DirectTexture` with the game viewport's RGBA pixels, flipped to top-to-bottom row order.
+Screenshots are **scheduled** (asynchronous), not synchronous. `requestScreenshot()` arms a
+capture of the **next rendered frame** (including changes made in the current `update`
+callback); `retrieveScreenshot()` returns the pixels as an `std::optional<DirectTexture>`
+once that frame has rendered — `nullopt` until then, the value exactly once, then `nullopt`
+again (consume-once). The capture is recorded **in-frame before present** (Vulkan windowed),
+so it is WSI-correct — no `WRITE-AFTER-PRESENT` hazard from reading a presented image.
 
 ```cpp
-// Call from within the update() callback:
-Nothofagus::DirectTexture screenshot = canvas.takeScreenshot();
+// Manual stepping (tick): schedule, render one frame, then retrieve.
+canvas.requestScreenshot();
+canvas.tick(16.0f);
+Nothofagus::DirectTexture screenshot = *canvas.retrieveScreenshot();
+
+// Inside a run() update callback: request anywhere (e.g. a key handler), then poll.
+canvas.run([&](float){
+    if (std::optional<Nothofagus::DirectTexture> shot = canvas.retrieveScreenshot())
+        use(*shot);          // ready the frame after requestScreenshot() was called
+    // ... canvas.requestScreenshot() from a controller action, etc.
+}, controller);
 
 // Access raw RGBA bytes for saving with an external image library (e.g. stb_image_plus):
 Nothofagus::TextureData data = screenshot.generateTextureData();
@@ -882,13 +898,18 @@ std::span<std::uint8_t> span = data.getDataSpan(); // width * height * 4 bytes, 
 Nothofagus::TextureId texId = canvas.addTexture(screenshot);
 ```
 
-**OpenGL note:** reads from `GL_BACK` (the just-rendered frame, point-sampled with `GL_NEAREST`) — valid only while an OpenGL context is current (i.e. inside `canvas.run()`/`tick()`). Reading the back buffer (rather than `GL_FRONT`) is what makes screenshots work in hidden-window/offscreen mode (`headless=true`), where the never-presented front buffer reads back as all-zero.
+`retrieveScreenshot()` only reads a stored optional (no blocking, no GPU work) so it is safe
+to call anywhere. `requestScreenshot()` must be paired with rendering at least one frame
+before the result appears; because the capture rides an existing frame there is no extra
+frame or steady-state cost, but it does mean the result is delivered one frame later.
+
+**OpenGL note:** reads from `GL_BACK` in the render backend's `endFrame` (after all drawing, before the window buffer swap), point-sampled with `GL_NEAREST`. Reading the back buffer (rather than `GL_FRONT`) is what makes screenshots work in hidden-window/offscreen mode (`headless=true`), where the never-presented front buffer reads back as all-zero.
 
 **Headless render resolution:** hidden windows (`headless=true`) opt out of HiDPI/high-pixel-density, so they render at exactly the logical canvas resolution (`screenSize × pixelSize`) regardless of the display's content scale. This keeps offscreen captures deterministic and pixel-identical across machines (and matches the windowless headless-Vulkan renderer). Visible windows still use the display's pixel density for on-screen crispness.
 
-**Vulkan windowed:** blits from the swapchain image through an intermediate R8G8B8A8 image (handles B8G8R8A8 format conversion) to a CPU-visible staging buffer.
+**Vulkan windowed:** the copy is recorded **into the frame's command buffer after the render pass but before present** (while the engine still owns the image — no WSI hazard): the swapchain image is blitted through an intermediate R8G8B8A8 image (handles B8G8R8A8 format conversion) into a CPU-visible staging buffer, then read back after the frame's fence signals (`finishScreenshot`).
 
-**Vulkan headless:** copies directly from the offscreen R8G8B8A8 image to a staging buffer via `vkCmdCopyImageToBuffer` — no intermediate blit or format conversion needed.
+**Vulkan headless:** no present, so `finishCapture` copies directly from the offscreen R8G8B8A8 image to a staging buffer via `vkCmdCopyImageToBuffer` after the frame — no intermediate blit or format conversion needed.
 
 ## Naming Conventions (C++)
 
@@ -918,7 +939,7 @@ Nothofagus::TextureId texId = canvas.addTexture(screenshot);
 | `test_keyboard.cpp` | Keyboard input handling |
 | `test_gamepad.cpp` | Gamepad input: stick movement, D-pad, buttons, ImGui status |
 | `test_create_destroy.cpp` | Object lifecycle |
-| `hello_screenshot.cpp` | `takeScreenshot()` — capture frame as DirectTexture, display thumbnail |
+| `hello_screenshot.cpp` | Scheduled screenshot (`requestScreenshot()` + `retrieveScreenshot()`) — capture frame as DirectTexture, display thumbnail |
 | `hello_headless.cpp` | Headless mode + `tick()` — no window, manual frame stepping, screenshot to terminal |
 | `hello_tilemap.cpp` | Tile-map mode of `IndirectTexture` — `setMap` + `setCell` over a layered atlas |
 | `hello_dense_land.cpp` | Dense lands via `DenseLand` + `DenseLandExplorer` pool — WASD camera, teleport, recreate, live memory breakdown, stress controls (auto-pan + edits/frame) |

--- a/examples/hello_headless.cpp
+++ b/examples/hello_headless.cpp
@@ -75,8 +75,10 @@ int main()
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    // Capture screenshot
-    Nothofagus::DirectTexture screenshot = canvas.takeScreenshot();
+    // Capture screenshot: schedule it, render one more frame, then retrieve the pixels.
+    canvas.requestScreenshot();
+    canvas.tick(16.0f);
+    Nothofagus::DirectTexture screenshot = *canvas.retrieveScreenshot();
     Nothofagus::TextureData textureData = screenshot.generateTextureData();
     std::span<std::uint8_t> pixels = textureData.getDataSpan();
     const int width  = static_cast<int>(textureData.width());

--- a/examples/hello_screenshot.cpp
+++ b/examples/hello_screenshot.cpp
@@ -92,6 +92,33 @@ int main()
 
     auto update = [&](float dt)
     {
+        // Pick up a scheduled screenshot once it is ready (the frame after SPACE was
+        // pressed). The returned DirectTexture owns its RGBA pixels (top-to-bottom) and
+        // can be saved with an external image library, e.g.:
+        //   auto data = shot->generateTextureData();
+        //   auto span = data.getDataSpan();
+        //   stb_image_plus::ImageData4 img(
+        //       {reinterpret_cast<stb_image_plus::Pixel4*>(span.data()), span.size() / 4},
+        //       data.width(), data.height());
+        //   img.write("screenshot.png");
+        if (std::optional<Nothofagus::DirectTexture> shot = canvas.retrieveScreenshot())
+        {
+            // Remove any existing screenshot content so its texture is garbage-collected.
+            if (screenshotBellotaId)
+            {
+                canvas.removeBellota(*screenshotBellotaId);
+                screenshotBellotaId.reset();
+            }
+            ensureFrame(); // persistent frame bellota, matched to the current resolution
+
+            spdlog::info("Screenshot captured: {}x{} px", shot->size().x, shot->size().y);
+            auto screenshotTexId = canvas.addTexture(*shot);
+            screenshotBellotaId  = canvas.addBellota({{thumbnailPos, thumbnailScale}, screenshotTexId, 1});
+
+            canvas.bellota(*screenshotFrameBellotaId).opacity() = 1.0f;
+            screenshotTimer = screenshotDisplayDurationMs;
+        }
+
         // Bounce the sprite inside the canvas bounds.
         spritePos += spriteVel * dt;
 
@@ -128,34 +155,10 @@ int main()
     Nothofagus::Controller controller;
     controller.registerAction({Nothofagus::Key::SPACE, Nothofagus::DiscreteTrigger::Press}, [&]()
     {
-        // Remove any existing screenshot content so its texture is garbage-collected.
-        if (screenshotBellotaId)
-        {
-            canvas.removeBellota(*screenshotBellotaId);
-            screenshotBellotaId.reset();
-        }
-
-        // Ensure the persistent frame bellota exists and matches the current resolution.
-        ensureFrame();
-
-        // Capture the current frame at game resolution (canvas.screenSize()).
-        // The returned DirectTexture owns its RGBA pixel data (top-to-bottom row order)
-        // and can be passed to an external image library for saving to disk, e.g.:
-        //
-        //   auto data = screenshot.generateTextureData();
-        //   auto span = data.getDataSpan();
-        //   stb_image_plus::ImageData4 img(
-        //       {reinterpret_cast<stb_image_plus::Pixel4*>(span.data()), span.size() / 4},
-        //       data.width(), data.height());
-        //   img.write("screenshot.png");
-        Nothofagus::DirectTexture screenshot = canvas.takeScreenshot();
-        spdlog::info("Screenshot captured: {}x{} px", screenshot.size().x, screenshot.size().y);
-
-        auto screenshotTexId = canvas.addTexture(screenshot);
-        screenshotBellotaId  = canvas.addBellota({{thumbnailPos, thumbnailScale}, screenshotTexId, 1});
-
-        canvas.bellota(*screenshotFrameBellotaId).opacity() = 1.0f;
-        screenshotTimer = screenshotDisplayDurationMs;
+        // Schedule a screenshot of the next rendered frame. Capture is deferred:
+        // the pixels arrive via canvas.retrieveScreenshot() on the following frame (see
+        // the poll at the top of update()), so it can be requested from inside a callback.
+        canvas.requestScreenshot();
     });
 
     canvas.run(update, controller);

--- a/include/canvas.h
+++ b/include/canvas.h
@@ -703,9 +703,17 @@ public:
     /// Close the canvas and clean up resources.
     void close();
 
-    /// Captures the last rendered frame visible to the user as a DirectTexture (RGBA).
-    /// Must be called from within the update() callback.
-    DirectTexture takeScreenshot() const;
+    /// Schedule a screenshot of the NEXT rendered frame (including changes made in the
+    /// current update callback). Safe to call from inside a run()/tick() update callback.
+    /// The capture is recorded in-frame before present (no WSI hazard); the pixels are
+    /// available via retrieveScreenshot() once that frame has been rendered.
+    void requestScreenshot();
+
+    /// Consume the scheduled screenshot as a DirectTexture (RGBA). Returns nullopt until
+    /// the frame that follows requestScreenshot() has rendered; returns the pixels exactly
+    /// once, then nullopt again. Safe to call anywhere (no blocking). Typical use:
+    ///   canvas.requestScreenshot(); canvas.tick(dt); auto shot = canvas.retrieveScreenshot();
+    std::optional<DirectTexture> retrieveScreenshot();
 
 private:
     struct Implementation;

--- a/source/backends/opengl_backend.cpp
+++ b/source/backends/opengl_backend.cpp
@@ -8,6 +8,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <stdexcept>
 #include <span>
+#include <utility>
 #ifdef TRACY_ENABLE
 #include <tracy/TracyOpenGL.hpp>
 #else
@@ -546,6 +547,8 @@ void OpenGLBackend::releaseFlat2DImguiHandle(DRenderTarget renderTarget, std::ui
 void OpenGLBackend::beginFrame(glm::vec3 clearColor, ViewportRect gameViewport,
                                 int framebufferWidth, int framebufferHeight)
 {
+    mCurrentGameViewport = gameViewport; // stashed for a deferred screenshot in endFrame
+
     // Clear entire framebuffer to black (fills letterbox/pillarbox bands).
     glViewport(0, 0, framebufferWidth, framebufferHeight);
     glDisable(GL_SCISSOR_TEST);
@@ -711,6 +714,14 @@ void OpenGLBackend::endFrame(ImDrawData* imguiData,
         ImGui_ImplOpenGL3_RenderDrawData(imguiData);
     }
     TracyGpuCollect;
+
+    // Deferred screenshot: read GL_BACK now, after all drawing but BEFORE the window
+    // backend swaps buffers (after swap, GL_BACK no longer holds this frame).
+    if (mScreenshotPending)
+    {
+        mScreenshotResult  = captureBackBuffer(mCurrentGameViewport, mScreenshotGameSize);
+        mScreenshotPending = false;
+    }
     // Buffer swap is performed by the window backend's endFrame().
 }
 
@@ -750,7 +761,18 @@ void OpenGLBackend::renderImguiDrawDataToRenderTarget(ImDrawData* imguiData,
     ImGui_ImplOpenGL3_RenderDrawData(imguiData);
 }
 
-ScreenshotPixels OpenGLBackend::takeScreenshot(ViewportRect gameViewport, glm::ivec2 gameSize) const
+void OpenGLBackend::armScreenshot(glm::ivec2 gameSize)
+{
+    mScreenshotPending  = true;
+    mScreenshotGameSize = gameSize;
+}
+
+std::optional<ScreenshotPixels> OpenGLBackend::finishScreenshot()
+{
+    return std::exchange(mScreenshotResult, std::nullopt);
+}
+
+ScreenshotPixels OpenGLBackend::captureBackBuffer(ViewportRect gameViewport, glm::ivec2 gameSize) const
 {
     const int gameWidth  = gameSize.x;
     const int gameHeight = gameSize.y;

--- a/source/backends/opengl_backend.h
+++ b/source/backends/opengl_backend.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <span>
 #include <string>
+#include <optional>
 
 namespace Nothofagus
 {
@@ -62,7 +63,10 @@ public:
     void imguiNewFrameForRenderTarget(DRenderTarget renderTarget);
     void renderImguiDrawDataToRenderTarget(ImDrawData* imguiData, DRenderTarget renderTarget);
 
-    ScreenshotPixels takeScreenshot(ViewportRect gameViewport, glm::ivec2 gameSize) const;
+    // Scheduled screenshot: armScreenshot() arms a capture; endFrame() reads GL_BACK
+    // (before the window buffer swap) when armed; finishScreenshot() returns the pixels.
+    void armScreenshot(glm::ivec2 gameSize);
+    std::optional<ScreenshotPixels> finishScreenshot();
 
     /// Allow FrameRunner to update a texture's filter parameters directly after upload.
     void setTextureMinFilter(DTexture texture, TextureSampleMode mode);
@@ -117,6 +121,15 @@ private:
     unsigned int compileShader(unsigned int type, const std::string& source);
     unsigned int createShaderProgram(unsigned int vertexShader, unsigned int fragmentShader);
     void setupVAO(OpenGLMesh& glMesh);
+
+    // Reads the game viewport region of GL_BACK into RGBA pixels (top-to-bottom).
+    ScreenshotPixels captureBackBuffer(ViewportRect gameViewport, glm::ivec2 gameSize) const;
+
+    // Deferred screenshot state.
+    bool         mScreenshotPending  = false;
+    glm::ivec2   mScreenshotGameSize = {};
+    ViewportRect mCurrentGameViewport = {};
+    std::optional<ScreenshotPixels> mScreenshotResult;
 };
 
 static_assert(RenderBackend<OpenGLBackend>,

--- a/source/backends/render_backend.h
+++ b/source/backends/render_backend.h
@@ -11,6 +11,7 @@
 #include <glm/glm.hpp>
 #include <concepts>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 struct ImDrawData;
@@ -30,7 +31,7 @@ struct SpriteDrawParams
     DTexture    mapTexture{};       ///< GPU map texture handle (only valid when mode == TextureMode::TileMap).
 };
 
-/// Pixel buffer returned by takeScreenshot(). RGBA, top-to-bottom row order.
+/// Pixel buffer produced by finishScreenshot(). RGBA, top-to-bottom row order.
 struct ScreenshotPixels
 {
     std::vector<std::uint8_t> data;
@@ -116,8 +117,11 @@ concept RenderBackend = requires(
     { backend.imguiNewFrameForRenderTarget(renderTarget)       } -> std::same_as<void>;
     { backend.renderImguiDrawDataToRenderTarget(imguiData, renderTarget) } -> std::same_as<void>;
 
-    // Screenshot: reads from the front buffer, returns RGBA pixels top-to-bottom.
-    { backend.takeScreenshot(viewport, canvasSize)             } -> std::same_as<ScreenshotPixels>;
+    // Screenshot (scheduled): armScreenshot() arms a capture of the next rendered frame
+    // (recorded in-frame before present); finishScreenshot() completes it at end of frame
+    // and returns the pixels (nullopt if none was captured this frame).
+    { backend.armScreenshot(canvasSize)                        } -> std::same_as<void>;
+    { backend.finishScreenshot()                               } -> std::same_as<std::optional<ScreenshotPixels>>;
 };
 
 } // namespace Nothofagus

--- a/source/backends/vulkan_backend.cpp
+++ b/source/backends/vulkan_backend.cpp
@@ -2193,6 +2193,12 @@ void VulkanBackend::endFrame(
     TracyVkCollect(mTracyVkContext, mActiveCommandBuffer);
 
     vkCmdEndRenderPass(mActiveCommandBuffer);
+
+    // Deferred screenshot: capture this frame's output while we still own the image —
+    // recorded here (before submit/present), read back after the fence. No-op unless armed.
+    mPresentation.recordCapture(mActiveCommandBuffer, mCurrentGameViewport,
+                                mFrames[mCurrentFrame].inFlight);
+
     vkEndCommandBuffer(mActiveCommandBuffer);
 
     FrameData& frame = mFrames[mCurrentFrame];
@@ -2277,13 +2283,19 @@ void VulkanBackend::renderImguiDrawDataToRenderTarget(ImDrawData* imguiData,
 }
 
 // ---------------------------------------------------------------------------
-// takeScreenshot()
+// Screenshot (scheduled) — arm a capture, then finish it at end of frame.
 // ---------------------------------------------------------------------------
 
-ScreenshotPixels VulkanBackend::takeScreenshot(ViewportRect gameViewport, glm::ivec2 gameSize) const
+void VulkanBackend::armScreenshot(glm::ivec2 gameSize)
 {
-    return mPresentation.takeScreenshot(mDevice, mAllocator, mCommandPool, mGraphicsQueue,
-                                        gameViewport, gameSize);
+    mPresentation.armCapture(gameSize);
+}
+
+std::optional<ScreenshotPixels> VulkanBackend::finishScreenshot()
+{
+    if (!mPresentation.captureReady())
+        return std::nullopt;
+    return mPresentation.finishCapture(mDevice, mAllocator, mCommandPool, mGraphicsQueue);
 }
 
 // ---------------------------------------------------------------------------

--- a/source/backends/vulkan_backend.h
+++ b/source/backends/vulkan_backend.h
@@ -19,6 +19,7 @@ using TracyVkCtx = void*;
 #include <array>
 #include <vector>
 #include <span>
+#include <optional>
 #include <cstdint>
 
 // Forward-declare VmaAllocator to avoid including vk_mem_alloc.h in every TU.
@@ -168,7 +169,10 @@ public:
     void imguiNewFrameForRenderTarget(DRenderTarget renderTarget);
     void renderImguiDrawDataToRenderTarget(ImDrawData* imguiData, DRenderTarget renderTarget);
 
-    ScreenshotPixels takeScreenshot(ViewportRect gameViewport, glm::ivec2 gameSize) const;
+    // Scheduled screenshot: armScreenshot() arms a capture of the next rendered frame
+    // (recorded in endFrame before present); finishScreenshot() reads it back after the fence.
+    void armScreenshot(glm::ivec2 gameSize);
+    std::optional<ScreenshotPixels> finishScreenshot();
 
     // Not part of the concept — called by FrameRunner to update filter after upload
     void setTextureMinFilter(DTexture dtexture, TextureSampleMode mode);

--- a/source/backends/vulkan_presentation.cpp
+++ b/source/backends/vulkan_presentation.cpp
@@ -125,7 +125,7 @@ void WindowedVulkanPresentation::createPresentationTarget(
         .add_fallback_format({VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR})
         .set_desired_present_mode(mPresentMode)               // vk-bootstrap falls back to FIFO if unsupported.
         .set_desired_min_image_count(kDesiredSwapchainImageCount)
-        .add_image_usage_flags(VK_IMAGE_USAGE_TRANSFER_SRC_BIT) // takeScreenshot() blits from the swapchain image.
+        .add_image_usage_flags(VK_IMAGE_USAGE_TRANSFER_SRC_BIT) // recordCapture() blits from the swapchain image for scheduled screenshots.
         .set_desired_extent(framebufferSize.width, framebufferSize.height)
         .build();
     if (!swapchainResult)
@@ -262,32 +262,65 @@ void WindowedVulkanPresentation::submitAndPresent(
 
 // --- Screenshot ---
 
-ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
-    VkDevice device, VmaAllocator allocator,
-    VkCommandPool commandPool, VkQueue graphicsQueue,
-    ViewportRect gameViewport, glm::ivec2 gameSize) const
+void WindowedVulkanPresentation::armCapture(glm::ivec2 gameSize)
 {
-    vkDeviceWaitIdle(device);
+    mCapturePending  = true;
+    mCaptureRecorded = false;
+    mCaptureGameSize = gameSize;
+}
 
-    const uint32_t     width  = static_cast<uint32_t>(gameSize.x);
-    const uint32_t     height = static_cast<uint32_t>(gameSize.y);
-    const VkDeviceSize bufSize = VkDeviceSize(width) * height * 4;
+bool WindowedVulkanPresentation::captureReady() const
+{
+    return mCapturePending && mCaptureRecorded;
+}
 
-    // Staging buffer (host-visible, host-coherent)
+void WindowedVulkanPresentation::destroyCaptureResources()
+{
+    if (mCaptureStaging != VK_NULL_HANDLE)
+    {
+        vmaDestroyBuffer(mAllocator, mCaptureStaging, mCaptureStagingAlloc);
+        mCaptureStaging       = VK_NULL_HANDLE;
+        mCaptureStagingAlloc  = VK_NULL_HANDLE;
+        mCaptureStagingMapped = nullptr;
+    }
+    if (mCaptureImage != VK_NULL_HANDLE)
+    {
+        vmaDestroyImage(mAllocator, mCaptureImage, mCaptureImageAlloc);
+        mCaptureImage      = VK_NULL_HANDLE;
+        mCaptureImageAlloc = VK_NULL_HANDLE;
+    }
+}
+
+// Record the pixel copy into the frame command buffer AFTER the render pass but BEFORE
+// present, while we still own the swapchain image — avoids the WRITE-AFTER-PRESENT hazard.
+void WindowedVulkanPresentation::recordCapture(
+    VkCommandBuffer commandBuffer, ViewportRect gameViewport, VkFence frameFence)
+{
+    if (!mCapturePending)
+        return;
+
+    // A previous armed-but-unfinished cycle could leave resources around; reset first.
+    destroyCaptureResources();
+
+    const uint32_t width  = static_cast<uint32_t>(mCaptureGameSize.x);
+    const uint32_t height = static_cast<uint32_t>(mCaptureGameSize.y);
+    mCaptureBufSize       = VkDeviceSize(width) * height * 4;
+
+    // Host-visible staging buffer — persists until finishCapture reads it back.
     VkBufferCreateInfo bufInfo{};
     bufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bufInfo.size  = bufSize;
+    bufInfo.size  = mCaptureBufSize;
     bufInfo.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-
     VmaAllocationCreateInfo stagingAllocInfo{};
     stagingAllocInfo.usage = VMA_MEMORY_USAGE_AUTO;
     stagingAllocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
                              VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    VmaAllocationInfo stagingMapped{};
+    vmaCreateBuffer(mAllocator, &bufInfo, &stagingAllocInfo,
+                    &mCaptureStaging, &mCaptureStagingAlloc, &stagingMapped);
+    mCaptureStagingMapped = stagingMapped.pMappedData;
 
-    VkBuffer stagingBuffer; VmaAllocation stagingAlloc; VmaAllocationInfo stagingMapped;
-    vmaCreateBuffer(allocator, &bufInfo, &stagingAllocInfo, &stagingBuffer, &stagingAlloc, &stagingMapped);
-
-    // Intermediate R8G8B8A8 image (handles B8G8R8A8 -> R8G8B8A8 format conversion)
+    // Intermediate R8G8B8A8 image (handles B8G8R8A8 -> R8G8B8A8 conversion + crop + flip).
     VkImageCreateInfo intermediateInfo{};
     intermediateInfo.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     intermediateInfo.imageType     = VK_IMAGE_TYPE_2D;
@@ -299,17 +332,15 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
     intermediateInfo.tiling        = VK_IMAGE_TILING_OPTIMAL;
     intermediateInfo.usage         = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     intermediateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
     VmaAllocationCreateInfo intermediateAllocInfo{};
     intermediateAllocInfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+    vmaCreateImage(mAllocator, &intermediateInfo, &intermediateAllocInfo,
+                   &mCaptureImage, &mCaptureImageAlloc, nullptr);
 
-    VkImage intermediateImage; VmaAllocation intermediateAlloc;
-    vmaCreateImage(allocator, &intermediateInfo, &intermediateAllocInfo,
-                   &intermediateImage, &intermediateAlloc, nullptr);
+    VkImage swapchainImage = mSwapchainImages[mCurrentImageIndex];
 
-    VkCommandBuffer commandBuffer = beginOneTimeCommand(device, commandPool);
-
-    // Transition swapchain image to TRANSFER_SRC
+    // Swapchain PRESENT_SRC -> TRANSFER_SRC. Source scope is the render pass's color
+    // writes (we captured this frame's output before it is presented).
     {
         VkImageMemoryBarrier barrier{};
         barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -317,16 +348,16 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
         barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        barrier.image               = mSwapchainImages[mCurrentImageIndex];
+        barrier.image               = swapchainImage;
         barrier.subresourceRange    = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-        barrier.srcAccessMask       = VK_ACCESS_MEMORY_READ_BIT;
+        barrier.srcAccessMask       = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         barrier.dstAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
         vkCmdPipelineBarrier(commandBuffer,
-            VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
             0, 0, nullptr, 0, nullptr, 1, &barrier);
     }
 
-    // Transition intermediate image to TRANSFER_DST
+    // Intermediate UNDEFINED -> TRANSFER_DST
     {
         VkImageMemoryBarrier barrier{};
         barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -334,7 +365,7 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
         barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        barrier.image               = intermediateImage;
+        barrier.image               = mCaptureImage;
         barrier.subresourceRange    = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         barrier.srcAccessMask       = 0;
         barrier.dstAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -343,7 +374,7 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
             0, 0, nullptr, 0, nullptr, 1, &barrier);
     }
 
-    // Blit swapchain -> intermediate (viewport crop + format conversion)
+    // Blit swapchain -> intermediate (viewport crop + Y-flip + format conversion)
     const int framebufferHeight = static_cast<int>(mSwapchainExtent.height);
     const int vulkanGameTop     = framebufferHeight - gameViewport.y - gameViewport.height;
     const int vulkanGameBottom  = framebufferHeight - gameViewport.y;
@@ -356,11 +387,11 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
     blit.dstOffsets[0]  = {0, 0, 0};
     blit.dstOffsets[1]  = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
     vkCmdBlitImage(commandBuffer,
-        mSwapchainImages[mCurrentImageIndex], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-        intermediateImage,                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        mCaptureImage,  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         1, &blit, VK_FILTER_NEAREST);
 
-    // Transition intermediate to TRANSFER_SRC for copy to buffer
+    // Intermediate TRANSFER_DST -> TRANSFER_SRC for the copy to buffer
     {
         VkImageMemoryBarrier barrier{};
         barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -368,7 +399,7 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
         barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        barrier.image               = intermediateImage;
+        barrier.image               = mCaptureImage;
         barrier.subresourceRange    = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
         barrier.dstAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
@@ -380,23 +411,23 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
     VkBufferImageCopy copyRegion{};
     copyRegion.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     copyRegion.imageExtent      = {width, height, 1};
-    vkCmdCopyImageToBuffer(commandBuffer, intermediateImage,
-                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, stagingBuffer, 1, &copyRegion);
+    vkCmdCopyImageToBuffer(commandBuffer, mCaptureImage,
+                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, mCaptureStaging, 1, &copyRegion);
 
-    // Host-read barrier
+    // Host-read barrier on the staging buffer
     {
         VkBufferMemoryBarrier barrier{};
         barrier.sType         = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
         barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
-        barrier.buffer        = stagingBuffer;
-        barrier.size          = bufSize;
+        barrier.buffer        = mCaptureStaging;
+        barrier.size          = mCaptureBufSize;
         vkCmdPipelineBarrier(commandBuffer,
             VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_HOST_BIT,
             0, 0, nullptr, 1, &barrier, 0, nullptr);
     }
 
-    // Restore swapchain image to PRESENT_SRC
+    // Restore swapchain image to PRESENT_SRC for the upcoming present
     {
         VkImageMemoryBarrier barrier{};
         barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -404,26 +435,35 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
         barrier.newLayout           = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        barrier.image               = mSwapchainImages[mCurrentImageIndex];
+        barrier.image               = swapchainImage;
         barrier.subresourceRange    = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         barrier.srcAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
-        barrier.dstAccessMask       = VK_ACCESS_MEMORY_READ_BIT;
+        barrier.dstAccessMask       = 0;
         vkCmdPipelineBarrier(commandBuffer,
             VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
             0, 0, nullptr, 0, nullptr, 1, &barrier);
     }
 
-    endOneTimeCommand(device, commandPool, graphicsQueue, commandBuffer);
+    mCaptureFence    = frameFence;
+    mCaptureRecorded = true;
+}
+
+ScreenshotPixels WindowedVulkanPresentation::finishCapture(
+    VkDevice device, VmaAllocator /*allocator*/, VkCommandPool /*commandPool*/, VkQueue /*graphicsQueue*/)
+{
+    // The GPU copy was recorded into the frame command buffer; wait for that frame to
+    // complete, then read the staging buffer. No extra submit needed.
+    vkWaitForFences(device, 1, &mCaptureFence, VK_TRUE, UINT64_MAX);
 
     ScreenshotPixels result;
-    result.width  = static_cast<int>(width);
-    result.height = static_cast<int>(height);
-    result.data.resize(bufSize);
-    std::memcpy(result.data.data(), stagingMapped.pMappedData, bufSize);
+    result.width  = mCaptureGameSize.x;
+    result.height = mCaptureGameSize.y;
+    result.data.resize(mCaptureBufSize);
+    std::memcpy(result.data.data(), mCaptureStagingMapped, mCaptureBufSize);
 
-    vmaDestroyBuffer(allocator, stagingBuffer, stagingAlloc);
-    vmaDestroyImage(allocator, intermediateImage, intermediateAlloc);
-
+    destroyCaptureResources();
+    mCapturePending  = false;
+    mCaptureRecorded = false;
     return result;
 }
 
@@ -431,6 +471,7 @@ ScreenshotPixels WindowedVulkanPresentation::takeScreenshot(
 
 void WindowedVulkanPresentation::shutdown(VkDevice device, VmaAllocator allocator, VkInstance instance)
 {
+    destroyCaptureResources();
     destroySwapchainResources();
     vkDestroySwapchainKHR(device, mSwapchain, nullptr);
 
@@ -539,7 +580,7 @@ void WindowedVulkanPresentation::recreateSwapchain()
         .add_fallback_format({VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR})
         .set_desired_present_mode(mPresentMode)               // Preserve the mode chosen at init across recreation.
         .set_desired_min_image_count(kDesiredSwapchainImageCount)
-        .add_image_usage_flags(VK_IMAGE_USAGE_TRANSFER_SRC_BIT) // takeScreenshot() blits from the swapchain image.
+        .add_image_usage_flags(VK_IMAGE_USAGE_TRANSFER_SRC_BIT) // recordCapture() blits from the swapchain image for scheduled screenshots.
         .set_desired_extent(framebufferSize.width, framebufferSize.height)
         .set_old_swapchain(mSwapchain)
         .build();
@@ -754,15 +795,38 @@ void HeadlessVulkanPresentation::submitAndPresent(
 
 // --- Screenshot ---
 
-ScreenshotPixels HeadlessVulkanPresentation::takeScreenshot(
+void HeadlessVulkanPresentation::armCapture(glm::ivec2 gameSize)
+{
+    mCapturePending  = true;
+    mCaptureRecorded = false;
+    mCaptureGameSize = gameSize;
+}
+
+void HeadlessVulkanPresentation::recordCapture(
+    VkCommandBuffer /*commandBuffer*/, ViewportRect gameViewport, VkFence /*frameFence*/)
+{
+    // Headless never presents; the owned color image is read out-of-band in
+    // finishCapture. Here we just note a capture is due for this frame's output.
+    if (!mCapturePending)
+        return;
+    mCaptureViewport = gameViewport;
+    mCaptureRecorded = true;
+}
+
+bool HeadlessVulkanPresentation::captureReady() const
+{
+    return mCapturePending && mCaptureRecorded;
+}
+
+ScreenshotPixels HeadlessVulkanPresentation::finishCapture(
     VkDevice device, VmaAllocator allocator,
-    VkCommandPool commandPool, VkQueue graphicsQueue,
-    ViewportRect gameViewport, glm::ivec2 gameSize) const
+    VkCommandPool commandPool, VkQueue graphicsQueue)
 {
     vkDeviceWaitIdle(device);
 
-    const uint32_t     width  = static_cast<uint32_t>(gameSize.x);
-    const uint32_t     height = static_cast<uint32_t>(gameSize.y);
+    const ViewportRect gameViewport = mCaptureViewport;
+    const uint32_t     width  = static_cast<uint32_t>(mCaptureGameSize.x);
+    const uint32_t     height = static_cast<uint32_t>(mCaptureGameSize.y);
     const VkDeviceSize bufSize = VkDeviceSize(width) * height * 4;
 
     // Staging buffer (host-visible, host-coherent)
@@ -853,6 +917,8 @@ ScreenshotPixels HeadlessVulkanPresentation::takeScreenshot(
 
     vmaDestroyBuffer(allocator, stagingBuffer, stagingAlloc);
 
+    mCapturePending  = false;
+    mCaptureRecorded = false;
     return result;
 }
 

--- a/source/backends/vulkan_presentation.h
+++ b/source/backends/vulkan_presentation.h
@@ -73,16 +73,19 @@ struct WindowedVulkanPresentation
     void          submitAndPresent(VkDevice device, VkQueue graphicsQueue,
                                    VkCommandBuffer commandBuffer, VkFence frameFence);
 
-    // --- Screenshot ---
-    ScreenshotPixels takeScreenshot(VkDevice device, VmaAllocator allocator,
-                                    VkCommandPool commandPool, VkQueue graphicsQueue,
-                                    ViewportRect gameViewport, glm::ivec2 gameSize) const;
+    // --- Screenshot (scheduled: recorded in-frame before present, read back after fence) ---
+    void armCapture(glm::ivec2 gameSize);
+    void recordCapture(VkCommandBuffer commandBuffer, ViewportRect gameViewport, VkFence frameFence);
+    bool captureReady() const;
+    ScreenshotPixels finishCapture(VkDevice device, VmaAllocator allocator,
+                                   VkCommandPool commandPool, VkQueue graphicsQueue);
 
     // --- Cleanup ---
     void shutdown(VkDevice device, VmaAllocator allocator, VkInstance instance);
 
 private:
     void recreateSwapchain();
+    void destroyCaptureResources();
     ScreenSize queryFramebufferSize() const;
     void createDepthResources();
     void destroyDepthResources();
@@ -122,6 +125,19 @@ private:
     // Store the native window handle for framebuffer size queries during
     // swapchain creation/recreation (Wayland doesn't provide currentExtent).
     void* mNativeWindowHandle = nullptr;
+
+    // Deferred screenshot capture: the copy is recorded into the frame command buffer
+    // before present (while we still own the image), then read back after the fence.
+    bool          mCapturePending       = false;  // armed for the next frame
+    bool          mCaptureRecorded      = false;  // recordCapture ran this cycle
+    glm::ivec2    mCaptureGameSize      = {};
+    VkFence       mCaptureFence         = VK_NULL_HANDLE;
+    VkImage       mCaptureImage         = VK_NULL_HANDLE;  // intermediate R8G8B8A8 (crop+convert+flip)
+    VmaAllocation mCaptureImageAlloc    = VK_NULL_HANDLE;
+    VkBuffer      mCaptureStaging       = VK_NULL_HANDLE;  // host-visible readback buffer
+    VmaAllocation mCaptureStagingAlloc  = VK_NULL_HANDLE;
+    void*         mCaptureStagingMapped = nullptr;
+    VkDeviceSize  mCaptureBufSize       = 0;
 };
 
 using ActiveVulkanPresentation = WindowedVulkanPresentation;
@@ -164,10 +180,12 @@ struct HeadlessVulkanPresentation
     void          submitAndPresent(VkDevice device, VkQueue graphicsQueue,
                                    VkCommandBuffer commandBuffer, VkFence frameFence);
 
-    // --- Screenshot ---
-    ScreenshotPixels takeScreenshot(VkDevice device, VmaAllocator allocator,
-                                    VkCommandPool commandPool, VkQueue graphicsQueue,
-                                    ViewportRect gameViewport, glm::ivec2 gameSize) const;
+    // --- Screenshot (scheduled; headless reads its owned, never-presented image) ---
+    void armCapture(glm::ivec2 gameSize);
+    void recordCapture(VkCommandBuffer commandBuffer, ViewportRect gameViewport, VkFence frameFence);
+    bool captureReady() const;
+    ScreenshotPixels finishCapture(VkDevice device, VmaAllocator allocator,
+                                   VkCommandPool commandPool, VkQueue graphicsQueue);
 
     // --- Cleanup ---
     void shutdown(VkDevice device, VmaAllocator allocator, VkInstance instance);
@@ -187,6 +205,12 @@ private:
 
     VkFramebuffer mFramebuffer = VK_NULL_HANDLE;
     VkExtent2D    mExtent      = {};
+
+    // Deferred screenshot state (headless has no present, so it reads its owned image).
+    bool         mCapturePending  = false;
+    bool         mCaptureRecorded = false;
+    glm::ivec2   mCaptureGameSize = {};
+    ViewportRect mCaptureViewport = {};
 };
 
 using ActiveVulkanPresentation = HeadlessVulkanPresentation;

--- a/source/canvas.cpp
+++ b/source/canvas.cpp
@@ -424,9 +424,14 @@ void Canvas::close()
     mImplPtr->frameRunner.close();
 }
 
-DirectTexture Canvas::takeScreenshot() const
+void Canvas::requestScreenshot()
 {
-    return mImplPtr->frameRunner.takeScreenshot();
+    mImplPtr->frameRunner.requestScreenshot();
+}
+
+std::optional<DirectTexture> Canvas::retrieveScreenshot()
+{
+    return mImplPtr->frameRunner.retrieveScreenshot();
 }
 
 }

--- a/source/frame_runner.cpp
+++ b/source/frame_runner.cpp
@@ -182,13 +182,16 @@ ScreenSize FrameRunner::windowSize() const
     return mWindow->getWindowSize();
 }
 
-DirectTexture FrameRunner::takeScreenshot() const
+void FrameRunner::requestScreenshot()
 {
+    mScreenshotArmed = true;
     const glm::ivec2 gameSize{static_cast<int>(mScreenSize.width), static_cast<int>(mScreenSize.height)};
-    ScreenshotPixels pixels = mBackend.takeScreenshot(mGameViewport, gameSize);
-    TextureData textureData(pixels.width, pixels.height, 1);
-    std::copy(pixels.data.begin(), pixels.data.end(), textureData.getDataSpan().begin());
-    return DirectTexture(std::move(textureData));
+    mBackend.armScreenshot(gameSize);
+}
+
+std::optional<DirectTexture> FrameRunner::retrieveScreenshot()
+{
+    return std::exchange(mScreenshotResult, std::nullopt);
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +302,20 @@ void FrameRunner::runOneFrame(Canvas& canvas, AssetRegistry& assets, ImguiRttMan
 
     const RenderSnapshot& snapshot = buildSnapshot(canvas, assets, imguiRtt, imguiImages, deltaTimeMS, update, controller);
     renderSnapshot(assets, imguiRtt, imguiImages, snapshot, deltaTimeMS, controller);
+
+    // Deferred screenshot: the backend recorded/read the capture during this frame's
+    // endFrame; finish it (read back after the fence) and hold the result for retrieval.
+    // Stays armed if the frame was skipped (e.g. swapchain recreation returned no image).
+    if (mScreenshotArmed)
+    {
+        if (std::optional<ScreenshotPixels> pixels = mBackend.finishScreenshot())
+        {
+            TextureData textureData(pixels->width, pixels->height, 1);
+            std::copy(pixels->data.begin(), pixels->data.end(), textureData.getDataSpan().begin());
+            mScreenshotResult = DirectTexture(std::move(textureData));
+            mScreenshotArmed = false;
+        }
+    }
 
     FrameMark;
 }

--- a/source/frame_runner.h
+++ b/source/frame_runner.h
@@ -155,8 +155,10 @@ public:
               ImguiImageManager& imguiImages,
               float deltaTimeMS, std::function<void(float)> update, Controller& controller);
 
-    /// Captures the last rendered frame visible to the user as a DirectTexture (RGBA).
-    DirectTexture takeScreenshot() const;
+    /// Arm a screenshot of the next rendered frame (captured in-frame before present).
+    void requestScreenshot();
+    /// Consume the captured frame once it is ready; nullopt until the armed frame renders.
+    std::optional<DirectTexture> retrieveScreenshot();
 
 private:
     void ensureSessionStarted(Controller& controller);
@@ -215,6 +217,11 @@ private:
 
     /// RTT passes queued by renderTo() during the update callback, executed before the main render.
     std::vector<std::pair<RenderTargetId, std::vector<BellotaId>>> mPendingRttPasses;
+
+    /// Deferred screenshot: armed by requestScreenshot(), finished at the end of the
+    /// captured frame; the result is held until retrieveScreenshot() consumes it.
+    bool mScreenshotArmed{false};
+    std::optional<DirectTexture> mScreenshotResult;
 
     PresentMode mPresentMode{DEFAULT_PRESENT_MODE}; ///< Swapchain / vsync preference (construction-time).
     std::optional<float> mTargetFps; ///< Frame-rate cap for run() (nullopt = unlimited). Runtime-settable.

--- a/tests/visual/present_mode_pixel_tests.cpp
+++ b/tests/visual/present_mode_pixel_tests.cpp
@@ -24,7 +24,9 @@ std::vector<std::uint8_t> screenshotBytes(Nothofagus::PresentMode mode)
         {15, 10}, "present_mode_test", {0.0f, 0.0f, 0.0f}, 1, 14,
         /*headless=*/true, mode);
     PresentModeTest::buildSceneAndTick(canvas, /*ticks=*/4);
-    Nothofagus::DirectTexture shot = canvas.takeScreenshot();
+    canvas.requestScreenshot();
+    canvas.tick(16.0f); // render one more frame to capture it
+    Nothofagus::DirectTexture shot = *canvas.retrieveScreenshot();
     Nothofagus::TextureData data = shot.generateTextureData();
     std::span<std::uint8_t> span = data.getDataSpan();
     return std::vector<std::uint8_t>(span.begin(), span.end());

--- a/tests/visual/present_mode_sync_tests.cpp
+++ b/tests/visual/present_mode_sync_tests.cpp
@@ -80,7 +80,10 @@ std::set<std::string> validationIdsForMode(Nothofagus::PresentMode mode)
             {15, 10}, "present_mode_test", {0.0f, 0.0f, 0.0f}, 1, 14,
             /*headless=*/true, mode);
         PresentModeTest::buildSceneAndTick(canvas, /*ticks=*/24);
-        (void)canvas.takeScreenshot();
+        // Schedule + render one more frame to exercise the in-frame capture path.
+        canvas.requestScreenshot();
+        canvas.tick(16.0f);
+        (void)canvas.retrieveScreenshot();
     }
 
     Nothofagus::setVulkanValidationCallback(nullptr);
@@ -105,10 +108,13 @@ TEST_CASE("present mode introduces no new validation hazards (Finding 2)", "[pre
     }
 
     if (unionIds.empty())
-        SKIP("No Vulkan validation messages captured — validation layer not loaded. "
-             "Run with the Vulkan SDK on VK_LAYER_PATH.");
+        SKIP("No VUID / SYNC-HAZARD ids captured. Either the validation layer is not loaded "
+             "(run with the Vulkan SDK on VK_LAYER_PATH), or the backend is clean — the "
+             "windowed screenshot/sync hazards this test used to observe are now all fixed, "
+             "so there is nothing to compare across present modes.");
 
-    // The set of distinct validation IDs must be identical across present modes.
+    // If any hazards do occur, the set of distinct validation IDs must be identical across
+    // present modes (a mode-specific hazard would mean the present mode introduced one).
     for (std::size_t i = 1; i < PresentModeTest::kAllModes.size(); ++i)
     {
         INFO("comparing " << PresentModeTest::modeName(PresentModeTest::kAllModes[0])

--- a/tests/visual/rendering_tests.cpp
+++ b/tests/visual/rendering_tests.cpp
@@ -202,6 +202,33 @@ static Nothofagus::Canvas makeCanvas(unsigned int width, unsigned int height)
     return Nothofagus::Canvas({width, height}, "test", {0.0f, 0.0f, 0.0f}, 1, 14, true);
 }
 
+// Screenshots are scheduled: arm a capture, render one more frame to capture it, then
+// retrieve. dt=0 so no time-based state advances — the captured frame matches the
+// settled scene the test already rendered. For bellota-only scenes (no per-frame update
+// callback), rendering an extra frame reproduces identical pixels.
+static Nothofagus::DirectTexture capture(Nothofagus::Canvas& canvas)
+{
+    canvas.requestScreenshot();
+    canvas.tick(0.0f);
+    return *canvas.retrieveScreenshot();
+}
+
+// For scenes whose content is submitted by a per-frame draw callback (ImGui / markdown):
+// run `frames` warmup frames with `draw`, arming the capture just before the LAST one so
+// the captured frame carries the callback's content (and, for animated scenes, is the same
+// frame the golden was authored from — no extra frame is rendered past the warmup count).
+template <class Draw>
+static Nothofagus::DirectTexture warmupCapture(Nothofagus::Canvas& canvas, int frames, Draw&& draw)
+{
+    for (int i = 0; i < frames; ++i)
+    {
+        if (i + 1 == frames)
+            canvas.requestScreenshot();
+        canvas.tick(16.0f, draw);
+    }
+    return *canvas.retrieveScreenshot();
+}
+
 // ---------------------------------------------------------------------------
 // Test: single red square on black background
 // ---------------------------------------------------------------------------
@@ -227,7 +254,7 @@ TEST_CASE("Single bellota renders correctly", "[rendering]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("single_bellota", canvas.takeScreenshot());
+    checkAgainstGolden("single_bellota", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -264,7 +291,7 @@ TEST_CASE("Multiple bellotas at different positions", "[rendering]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("multiple_positions", canvas.takeScreenshot());
+    checkAgainstGolden("multiple_positions", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +332,7 @@ TEST_CASE("Depth ordering occludes correctly", "[rendering]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("depth_ordering", canvas.takeScreenshot());
+    checkAgainstGolden("depth_ordering", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -337,7 +364,7 @@ TEST_CASE("Invisible bellota is not rendered", "[rendering]")
         canvas.tick(16.0f);
 
     // Should be entirely black
-    checkAgainstGolden("invisible_bellota", canvas.takeScreenshot());
+    checkAgainstGolden("invisible_bellota", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -350,7 +377,7 @@ TEST_CASE("Clear color fills background", "[rendering]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("clear_color", canvas.takeScreenshot());
+    checkAgainstGolden("clear_color", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -379,7 +406,7 @@ TEST_CASE("Semi-transparent bellota blends with background", "[rendering]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("opacity_blend", canvas.takeScreenshot());
+    checkAgainstGolden("opacity_blend", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -414,7 +441,7 @@ TEST_CASE("Custom mesh renders correctly", "[rendering][mesh]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("custom_mesh_triangle", canvas.takeScreenshot());
+    checkAgainstGolden("custom_mesh_triangle", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -458,7 +485,7 @@ TEST_CASE("Auto-quad regenerates on setTexture", "[rendering][mesh]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("auto_quad_resized_after_setTexture", canvas.takeScreenshot());
+    checkAgainstGolden("auto_quad_resized_after_setTexture", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -513,7 +540,7 @@ TEST_CASE("setMesh swaps geometry mid-frame", "[rendering][mesh]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("setMesh_swap_geometry", canvas.takeScreenshot());
+    checkAgainstGolden("setMesh_swap_geometry", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -588,10 +615,8 @@ TEST_CASE("ImGui overlay bars render centered", "[rendering][imgui]")
 {
     auto canvas = makeCanvas(100, 100);
 
-    for (int i = 0; i < kImguiWarmupFrames; ++i)
-        canvas.tick(16.0f, [&](float) { drawOverlayBars(canvas, "HEADER", "FOOTER"); });
-
-    checkAgainstGolden("imgui_overlay_basic", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_overlay_basic", warmupCapture(canvas, kImguiWarmupFrames,
+        [&](float) { drawOverlayBars(canvas, "HEADER", "FOOTER"); }));
 }
 
 TEST_CASE("ImGui overlay bars track pillarbox offset", "[rendering][imgui]")
@@ -602,10 +627,8 @@ TEST_CASE("ImGui overlay bars track pillarbox offset", "[rendering][imgui]")
     Nothofagus::Canvas canvas({200, 100}, "test", {0.0f, 0.0f, 0.0f}, 1, 14, true);
     canvas.setScreenSize({100, 100});
 
-    for (int i = 0; i < kImguiWarmupFrames; ++i)
-        canvas.tick(16.0f, [&](float) { drawOverlayBars(canvas, "HEADER", "FOOTER"); });
-
-    checkAgainstGolden("imgui_overlay_pillarbox", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_overlay_pillarbox", warmupCapture(canvas, kImguiWarmupFrames,
+        [&](float) { drawOverlayBars(canvas, "HEADER", "FOOTER"); }));
 }
 
 // ---------------------------------------------------------------------------
@@ -627,6 +650,9 @@ TEST_CASE("Markdown tables render with wrapped columns", "[rendering][imgui]")
         "| again | Second long row sharing the column width. |\n";
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
             ImGui::SetNextWindowSize(ImVec2(220.0f, 160.0f), ImGuiCond_Always);
@@ -635,8 +661,9 @@ TEST_CASE("Markdown tables render with wrapped columns", "[rendering][imgui]")
             markdown.print(kTable);
             ImGui::End();
         });
+    }
 
-    checkAgainstGolden("markdown_tables", canvas.takeScreenshot());
+    checkAgainstGolden("markdown_tables", *canvas.retrieveScreenshot());
 }
 
 // ---------------------------------------------------------------------------
@@ -667,6 +694,9 @@ TEST_CASE("Markdown renders an inline registered image", "[rendering][imgui]")
         "Missing: ![x](nope)\n";
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
             ImGui::SetNextWindowSize(ImVec2(160.0f, 120.0f), ImGuiCond_Always);
@@ -675,8 +705,9 @@ TEST_CASE("Markdown renders an inline registered image", "[rendering][imgui]")
             markdown.print(kDoc);
             ImGui::End();
         });
+    }
 
-    checkAgainstGolden("markdown_inline_image", canvas.takeScreenshot());
+    checkAgainstGolden("markdown_inline_image", *canvas.retrieveScreenshot());
 }
 
 // ---------------------------------------------------------------------------
@@ -710,6 +741,9 @@ TEST_CASE("Markdown inline image respects width bounds", "[rendering][imgui]")
         "Small: ![small](small)\n";
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
             ImGui::SetNextWindowSize(ImVec2(160.0f, 140.0f), ImGuiCond_Always);
@@ -718,8 +752,9 @@ TEST_CASE("Markdown inline image respects width bounds", "[rendering][imgui]")
             markdown.print(kDoc);
             ImGui::End();
         });
+    }
 
-    checkAgainstGolden("markdown_image_bounds", canvas.takeScreenshot());
+    checkAgainstGolden("markdown_image_bounds", *canvas.retrieveScreenshot());
 }
 
 // ---------------------------------------------------------------------------
@@ -764,6 +799,9 @@ TEST_CASE("Markdown animated inline image", "[rendering][imgui]")
         "![spinner](spinner) icon, which must still render at full size.\n";
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             Nothofagus::Visual v{texId};
             v.currentLayer() = static_cast<std::size_t>(i % 4);
@@ -776,8 +814,9 @@ TEST_CASE("Markdown animated inline image", "[rendering][imgui]")
             markdown.print(kDoc);
             ImGui::End();
         });
+    }
 
-    checkAgainstGolden("markdown_animated_inline_image", canvas.takeScreenshot());
+    checkAgainstGolden("markdown_animated_inline_image", *canvas.retrieveScreenshot());
 }
 
 // ---------------------------------------------------------------------------
@@ -812,6 +851,9 @@ TEST_CASE("Markdown image width modes", "[rendering][imgui]")
     static constexpr const char* kDoc =
         "Full:\n\n![full](mode-full)\n\nMax 40%:\n\n![max](mode-max)\n\nMin 30%:\n\n![min](mode-min)\n";
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             ImGui::SetNextWindowPos(ImVec2(0,0), ImGuiCond_Always);
             ImGui::SetNextWindowSize(ImVec2(640,520), ImGuiCond_Always);
@@ -820,7 +862,8 @@ TEST_CASE("Markdown image width modes", "[rendering][imgui]")
             markdown.print(kDoc);
             ImGui::End();
         });
-    checkAgainstGolden("markdown_width_modes", canvas.takeScreenshot());
+    }
+    checkAgainstGolden("markdown_width_modes", *canvas.retrieveScreenshot());
 }
 
 // ---------------------------------------------------------------------------
@@ -852,6 +895,9 @@ TEST_CASE("Markdown raw image overflows the column uncapped", "[rendering][imgui
     });
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
             ImGui::SetNextWindowSize(ImVec2(200.0f, 80.0f), ImGuiCond_Always);
@@ -860,8 +906,9 @@ TEST_CASE("Markdown raw image overflows the column uncapped", "[rendering][imgui
             markdown.print("![raw](raw)\n");
             ImGui::End();
         });
+    }
 
-    checkAgainstGolden("markdown_raw_overflow", canvas.takeScreenshot());
+    checkAgainstGolden("markdown_raw_overflow", *canvas.retrieveScreenshot());
 }
 
 // ---------------------------------------------------------------------------
@@ -900,10 +947,8 @@ TEST_CASE("ImGui standard UI at content scale 1x", "[rendering][imgui]")
     auto canvas = makeCanvas(120, 90);
     canvas.setContentScaleOverride(1.0f);
 
-    for (int i = 0; i < kImguiWarmupFrames; ++i)
-        canvas.tick(16.0f, [&](float) { drawStandardUi(canvas); });
-
-    checkAgainstGolden("imgui_dpi_scale_1x", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_dpi_scale_1x", warmupCapture(canvas, kImguiWarmupFrames,
+        [&](float) { drawStandardUi(canvas); }));
 }
 
 TEST_CASE("ImGui standard UI scales font and metrics at 2x", "[rendering][imgui]")
@@ -911,10 +956,8 @@ TEST_CASE("ImGui standard UI scales font and metrics at 2x", "[rendering][imgui]
     auto canvas = makeCanvas(240, 180);
     canvas.setContentScaleOverride(2.0f);
 
-    for (int i = 0; i < kImguiWarmupFrames; ++i)
-        canvas.tick(16.0f, [&](float) { drawStandardUi(canvas); });
-
-    checkAgainstGolden("imgui_dpi_scale_2x", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_dpi_scale_2x", warmupCapture(canvas, kImguiWarmupFrames,
+        [&](float) { drawStandardUi(canvas); }));
 }
 
 TEST_CASE("ImGui overlay bars scale with content scale", "[rendering][imgui]")
@@ -923,10 +966,8 @@ TEST_CASE("ImGui overlay bars scale with content scale", "[rendering][imgui]")
     canvas.setContentScaleOverride(2.0f);
 
     // Header only (empty footer) so the bottom of the viewport stays visible.
-    for (int i = 0; i < kImguiWarmupFrames; ++i)
-        canvas.tick(16.0f, [&](float) { drawOverlayBars(canvas, "HEADER", ""); });
-
-    checkAgainstGolden("imgui_overlay_scaled", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_overlay_scaled", warmupCapture(canvas, kImguiWarmupFrames,
+        [&](float) { drawOverlayBars(canvas, "HEADER", ""); }));
 }
 
 // ---------------------------------------------------------------------------
@@ -946,7 +987,7 @@ TEST_CASE("Tilemap text renders a single line", "[rendering][text]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("tilemap_text_single_line", canvas.takeScreenshot());
+    checkAgainstGolden("tilemap_text_single_line", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -970,7 +1011,7 @@ TEST_CASE("Tilemap text renders multiple lines", "[rendering][text]")
     for (int i = 0; i < 3; ++i)
         canvas.tick(16.0f);
 
-    checkAgainstGolden("tilemap_text_multi_line", canvas.takeScreenshot());
+    checkAgainstGolden("tilemap_text_multi_line", capture(canvas));
 }
 
 // ---------------------------------------------------------------------------
@@ -1041,13 +1082,17 @@ TEST_CASE("imguiImage draws a scaled paletted visual", "[rendering][imgui]")
         Nothofagus::Visual{texId}, Nothofagus::ImguiImageSize::Scaled{glm::vec2(6.0f)}); // 8x8 -> 48x48
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             beginFullViewportWindow(canvas, "##visual_scaled");
             canvas.imguiImage(imageId);
             endFullViewportWindow();
         });
+    }
 
-    checkAgainstGolden("imgui_visual_scaled", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_visual_scaled", *canvas.retrieveScreenshot());
 }
 
 TEST_CASE("imguiImage explicit logical size Fit vs Stretch on a custom mesh", "[rendering][imgui][mesh]")
@@ -1075,6 +1120,9 @@ TEST_CASE("imguiImage explicit logical size Fit vs Stretch on a custom mesh", "[
         triVisual, Nothofagus::ImguiImageSize::Explicit{{80.0f, 40.0f}, Nothofagus::ImguiImageFit::Stretch});
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             beginFullViewportWindow(canvas, "##visual_fit_stretch");
             canvas.imguiImage(fitId);
@@ -1082,8 +1130,9 @@ TEST_CASE("imguiImage explicit logical size Fit vs Stretch on a custom mesh", "[
             canvas.imguiImage(stretchId);
             endFullViewportWindow();
         });
+    }
 
-    checkAgainstGolden("imgui_visual_logical_fit_stretch", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_visual_logical_fit_stretch", *canvas.retrieveScreenshot());
 }
 
 TEST_CASE("imguiImage draws a DirectTexture honoring magFilter", "[rendering][imgui]")
@@ -1111,6 +1160,9 @@ TEST_CASE("imguiImage draws a DirectTexture honoring magFilter", "[rendering][im
         Nothofagus::Visual{linearTexId}, Nothofagus::ImguiImageSize::Scaled{glm::vec2(20.0f)});  // smooth blend
 
     for (int i = 0; i < kImguiWarmupFrames; ++i)
+    {
+        if (i + 1 == kImguiWarmupFrames)
+            canvas.requestScreenshot();
         canvas.tick(16.0f, [&](float) {
             beginFullViewportWindow(canvas, "##visual_direct_texture");
             canvas.imguiImage(nearestId);
@@ -1118,7 +1170,8 @@ TEST_CASE("imguiImage draws a DirectTexture honoring magFilter", "[rendering][im
             canvas.imguiImage(linearId);
             endFullViewportWindow();
         });
+    }
 
-    checkAgainstGolden("imgui_visual_direct_texture", canvas.takeScreenshot());
+    checkAgainstGolden("imgui_visual_direct_texture", *canvas.retrieveScreenshot());
 }
 


### PR DESCRIPTION
Replaces the synchronous `takeScreenshot()` with a **scheduled** (request / retrieve) API
so the windowed Vulkan capture no longer reads an already-presented swapchain image.

## Why

`takeScreenshot()` read `mSwapchainImages[mCurrentImageIndex]` **after it was presented**,
with no synchronization against the present. Only a later `vkAcquireNextImageKHR` releases a
presented image, and `vkDeviceWaitIdle` does not cover async presentation — so the copy raced
the compositor. Synchronization validation flagged this as `SYNC-HAZARD-WRITE-AFTER-PRESENT`.
The fix is to stop reading after present and instead capture the frame **in-frame, before
present, while we still own the image**. Because the CPU pixels are only ready after that
frame's fence signals, the API becomes scheduled/asynchronous.

## API (breaking)

```cpp
void requestScreenshot();                           // arm a capture of the NEXT rendered frame
std::optional<DirectTexture> retrieveScreenshot();  // consume-once; nullopt until ready
```

- `requestScreenshot()` arms a capture; the next frame that renders (the in-flight frame if
  called from inside an `update` callback, else the next `tick`/`run` iteration) captures it —
  including changes made in that update.
- `retrieveScreenshot()` returns the pixels exactly once, then `nullopt` again. It only reads a
  stored optional (no blocking, no GPU work), so it is safe to call anywhere.
- For `tick()` the result is ready the instant `tick()` returns; for `run()`, request in one
  `update` and retrieve in a later one.

```cpp
// Manual / headless:
canvas.requestScreenshot();
canvas.tick(16.0f);
Nothofagus::DirectTexture shot = *canvas.retrieveScreenshot();

// Inside a run() update callback (e.g. a key handler requests; poll for the result):
if (std::optional<Nothofagus::DirectTexture> shot = canvas.retrieveScreenshot())
    use(*shot);
```

No extra rendered frame, no callbacks/futures, no per-frame steady-state cost; the result is
delivered one frame after the request.

## Implementation

- **RenderBackend concept**: `takeScreenshot()` → `armScreenshot(gameSize)` +
  `finishScreenshot() -> std::optional<ScreenshotPixels>`. The in-frame recording lives in each
  backend's existing `endFrame`.
- **Windowed Vulkan** (`vulkan_presentation.*`): `recordCapture()` runs in `endFrame` after the
  render pass and before `submitAndPresent`, blitting the swapchain image → intermediate
  R8G8B8A8 (crop + Y-flip + `B8G8R8A8` convert, reusing the existing logic) → staging buffer,
  and restoring the swapchain image to `PRESENT_SRC_KHR` for present. `finishCapture()` waits the
  frame fence and copies the staging buffer to CPU. The old post-present reader is removed.
- **OpenGL** (`opengl_backend.*`): reads `GL_BACK` in `endFrame` (before the window buffer swap).
- **Headless Vulkan**: unchanged behavior — reads its owned, never-presented image in
  `finishCapture()`; it never had the hazard.
- **FrameRunner / Canvas**: `requestScreenshot()` arms the backend; `runOneFrame` finishes the
  capture at end of frame and stores the `std::optional<DirectTexture>`; `retrieveScreenshot()`
  hands it out once.

## Call sites & docs

Updated all callers to request / render / retrieve: `hello_headless`, `hello_screenshot` (now
requests from inside the `run()` update callback and polls for the result), and the visual /
golden tests (a `warmupCapture` helper arms before the last warmup frame, so the captured frame
carries the ImGui/markdown content and matches the animated golden — no extra frame). Screenshot
docs in `CLAUDE.md` and the `Canvas` header updated to the scheduled model.

## Verification

- Builds clean: windowed Vulkan (GLFW/SDL3), headless Vulkan, and OpenGL.
- **`SYNC-HAZARD-WRITE-AFTER-PRESENT` is gone** — `present_mode_sync_tests` under synchronization
  validation now captures zero VUID / SYNC-HAZARD ids (the windowed backend is fully clean; the
  test skips as there is nothing left to compare).
- Pixels unchanged: `present_mode_pixel_tests` passes and the SwiftShader golden suite passes
  (25/25) — same pixel path, just recorded before present.
- `hello_headless` on windowed Vulkan under validation produces the correct image with **zero**
  validation hazards; OpenGL `hello_headless` produces the correct image.
